### PR TITLE
Extracting pedersen hashing into separate function and adding unit test

### DIFF
--- a/pepper/Makefile
+++ b/pepper/Makefile
@@ -15,8 +15,6 @@ TEST_LDFLAGS = -lgtest -lpthread
 TEST_IFLAGS = -I./
 TEST_BIN = test/bin/
 
-APP_TESTS := $(shell find test/apps/ -name '*_test.cpp')
-
 # We need to use ALT_BN_128 for all ethereum related work
 change-curve: check-env
 	sed -i 's/DCURVE_BN128/DCURVE_ALT_BN128/g' $(PEPPER)/pepper/Makefile

--- a/pepper/Makefile
+++ b/pepper/Makefile
@@ -15,6 +15,8 @@ TEST_LDFLAGS = -lgtest -lpthread
 TEST_IFLAGS = -I./
 TEST_BIN = test/bin/
 
+APP_TESTS := $(shell find test/apps/ -name '*_test.cpp')
+
 # We need to use ALT_BN_128 for all ethereum related work
 change-curve: check-env
 	sed -i 's/DCURVE_BN128/DCURVE_ALT_BN128/g' $(PEPPER)/pepper/Makefile
@@ -48,9 +50,11 @@ test: unit-tests gadget-tests e2e-tests
 e2e-tests: check-env
 	test/e2e/hash_transform.sh
 
-unit-tests: test/apps/hash_transform_test.cpp
-	$(CXX) -DTEST $(TEST_IFLAGS) $< -o $(TEST_BIN)/run_unit_tests $(TEST_LDFLAGS)
-	$(TEST_BIN)/run_unit_tests
+unit-tests: $(patsubst test/apps/%.cpp, app_%, $(wildcard test/apps/*_test.cpp))
+
+app_%_test: test/apps/%_test.cpp
+	$(CXX) $(CXXFLAGS) -DTEST $(TEST_IFLAGS) $< -o $(TEST_BIN)/$@ $(TEST_LDFLAGS)
+	$(TEST_BIN)/$@
 
 gadget-tests: test/gadgets/main.cpp
 	$(CXX) $(CXXFLAGS) $(IFLAGS) -Iext_gadget/ $< ext_gadget/gadgets/*.cpp ext_gadget/gadgets/jubjub/*.cpp -o $(TEST_BIN)/run_gadget_tests $(LDFLAGS) $(TEST_LDFLAGS)

--- a/pepper/apps/dex_common.h
+++ b/pepper/apps/dex_common.h
@@ -45,7 +45,7 @@ struct Private readPrivateInput() {
  * Afterwards verify that bits sum up to number.
  */
 struct Decomposed { bool bits[254]; };
-void decomposeBits(uint32_t number, bool bits[254]) {
+void decomposeBits(uint32_t number, bool* bits) {
     struct Decomposed result[1] = { 0 };
     uint32_t lens[1] = {1};
     uint32_t input[1] = {number};

--- a/pepper/apps/dex_common.h
+++ b/pepper/apps/dex_common.h
@@ -1,15 +1,17 @@
+#pragma once
+
 #ifdef PEPPER
 // Pepper (C) doesn't know bool
 typedef unsigned char bool;
 #endif
 
 /**
- * Copies `lenght` bits from source to target
+ * Copies `length` bits from source to target
  */
-void copyBits(bool* source, bool* target, uint32_t length) {
+void copyBits(bool* source, uint32_t source_offset, bool* target, uint32_t target_offset, uint32_t length) {
     uint32_t index;
     for (index = 0; index < length; index++) {
-        target[index] = source[index];
+        target[target_offset+index] = source[source_offset+index];
     }
 }
 
@@ -43,7 +45,7 @@ struct Private readPrivateInput() {
  * Afterwards verify that bits sum up to number.
  */
 struct Decomposed { bool bits[254]; };
-void decomposeBits(uint32_t number, bool* bits) {
+void decomposeBits(uint32_t number, bool bits[254]) {
     struct Decomposed result[1] = { 0 };
     uint32_t lens[1] = {1};
     uint32_t input[1] = {number};
@@ -51,5 +53,5 @@ void decomposeBits(uint32_t number, bool* bits) {
     exo_compute(exo1_inputs,lens,result,1);
     uint32_t sum = sumBits(result->bits, 254);
     assert_zero(sum - number);
-	copyBits(result->bits, bits, 254);
+	copyBits(result->bits, 0, bits, 0, 254);
 }

--- a/pepper/apps/hash_transform.c
+++ b/pepper/apps/hash_transform.c
@@ -16,7 +16,6 @@ void compute(struct In *input, struct Out *output){
         copyBits(shaHash->digest, 0, shaIn, 0, 256);
         copyBits(pInput.orders, index, shaIn, 259, 253);
         ext_gadget(shaIn, shaHash, 0);
-        uint32_t result = sumBits(shaHash->digest, 256);
     }
 
     // assert final sha hash is equal with public input

--- a/pepper/apps/hash_transform.c
+++ b/pepper/apps/hash_transform.c
@@ -1,33 +1,24 @@
 #include "hash_transform.h"
 #include "dex_common.h"
+#include "hashing.h"
 
 struct ShaHash { bool digest[256]; };
-struct PedersenHash { uint32_t values[2]; }; /* [x,y] */
 
 void compute(struct In *input, struct Out *output){
     // Read private input
     struct Private pInput = readPrivateInput();
     struct ShaHash shaHash[1] = { 0 };
-    struct PedersenHash pedersenHash[1] = { 0 };
 
     bool shaIn[512] = { 0 };
-    bool pedersenInput[508] = { 0 };
-
     uint32_t index;
-    for (index=0; index < ORDERS; index++) {
+    for (index=0; index < ORDERS*253; index+=253) {
         // sha hash
-        copyBits(shaHash->digest, shaIn, 256);
-        copyBits(pInput.orders[index], shaIn+259, 253);
+        copyBits(shaHash->digest, 0, shaIn, 0, 256);
+        copyBits(pInput.orders, index, shaIn, 259, 253);
         ext_gadget(shaIn, shaHash, 0);
+        uint32_t result = sumBits(shaHash->digest, 256);
+    }
 
-        // pedersen hash
-        bool decomposed[254] = { 0 };
-        decomposeBits(pedersenHash->values[0], decomposed);
-        copyBits(decomposed, pedersenInput, 254);
-        copyBits(pInput.orders[index], pedersenInput+255, 253);
-        ext_gadget(pedersenInput, pedersenHash, 1); 
-    };
-    
     // assert final sha hash is equal with public input
     int128 resultL = sumBits(shaHash->digest, 128);
     int128 resultR = sumBits(shaHash->digest+128, 128);
@@ -35,7 +26,5 @@ void compute(struct In *input, struct Out *output){
     assert_zero(resultL - input->shaHashL);
     assert_zero(resultR - input->shaHashR);
 
-    // Write final pederson hash to output
-    output->pedersenHash[0] = pedersenHash->values[0];
-    output->pedersenHash[1] = pedersenHash->values[1];
+    output->pedersenHash = hashPedersen(pInput.orders, ORDERS*253, 253);
 }

--- a/pepper/apps/hash_transform.h
+++ b/pepper/apps/hash_transform.h
@@ -2,8 +2,8 @@
 
 #define ORDERS 2
 
-struct Private { bool orders[ORDERS][253]; };
+struct Private { bool orders[ORDERS * 253]; };
 struct In { int128 shaHashL; int128 shaHashR; };
-struct Out { uint32_t pedersenHash[2]; };
+struct Out { uint32_t pedersenHash; };
 
 void compute(struct In *input, struct Out *output);

--- a/pepper/apps/hashing.h
+++ b/pepper/apps/hashing.h
@@ -1,0 +1,29 @@
+#include <stdint.h>
+#include "dex_common.h"
+
+/**
+ * Hashes the given input of size `inputSize` by dividing it into windows of size 
+ * `chunkSize` and chaining their pedersen hashes together and returns the x-coordinate
+ * of the result. The starting point of the chain is the point at infinity (x = 0)
+ *
+ * E.g. hashPedersen([0,0,1,1], 4, 2) == hash(hash(O, [0,0]), [1,1])
+ */
+struct PedersenHash { uint32_t values[2]; }; /* resulting Point(x,y) */
+uint32_t hashPedersen(bool *in, uint32_t inputSize, uint32_t chunkSize) {
+    struct PedersenHash result[1] = { 0 };
+    uint32_t index;
+    for (index = 0; index < inputSize; index += chunkSize) {
+        // Decompose x-coordinate from previous result to binary
+        bool decomposed[254] = { 0 };
+        decomposeBits(result->values[0], decomposed);
+
+        // Fill pedersen input, left with previous result
+        bool pedersenInput[508] = { 0 };
+        copyBits(decomposed, 0, pedersenInput, 0, 254);
+        uint32_t padding = 254 - chunkSize;
+        copyBits(in, index, pedersenInput, 254+padding, chunkSize);
+
+        ext_gadget(pedersenInput, result, 1);
+    }
+    return result->values[0];
+}

--- a/pepper/test/apps/hash_transform_test.cpp
+++ b/pepper/test/apps/hash_transform_test.cpp
@@ -12,7 +12,7 @@ TEST(HashTransformTest, TransformWithMatchingSHA) {
     struct In input = { 0,3 }; /* resulting SHA after two rounds will be 11 */
     struct Out output;
     compute(&input, &output);
-    ASSERT_EQ(output.pedersenHash[0], 2);
+    ASSERT_EQ(output.pedersenHash, 2);
 }
 
 TEST(HashTransformTest, TransformWithWrongSHA) {

--- a/pepper/test/apps/hashing_test.cpp
+++ b/pepper/test/apps/hashing_test.cpp
@@ -1,0 +1,57 @@
+#include <cassert>
+#include <gtest/gtest.h>
+#include "declarations.h"
+
+#define EXT_GADGET_OVERRIDE
+struct Private {};
+
+#include <apps/hashing.h>
+#include "util.h"
+
+std::vector< std::vector<bool> > pedersenCalls;
+void ext_gadget(void* in, void* out, uint32_t gadget) {
+    assert(gadget == 1); // PedersenHashGadget
+    bool *boolIn = (bool*) in;
+    std::vector<bool> b(boolIn, boolIn + 508);
+    pedersenCalls.push_back(b);
+}
+
+TEST(HashPedersenTest, SingleChunk) { 
+    pedersenCalls.clear();
+    bool input[6] = {0, 0, 0, 1, 1, 1};
+    std::vector<bool> inputV(input, input+6);
+
+    hashPedersen(input, 6, 6);
+
+    ASSERT_EQ(pedersenCalls.size(), 1);
+    auto& first = pedersenCalls.front();
+    ASSERT_EQ(first.size(), 508);
+    ASSERT_TRUE(std::equal(first.cbegin() + 502, first.cend(), inputV.cbegin()));
+}
+
+TEST(HashPedersenTest, MultipleChunks) {
+    pedersenCalls.clear();
+    bool input[6] = {0, 0, 0, 1, 1, 1};
+    std::vector<bool> inputV(input, input+6);
+    
+    hashPedersen(input, 6, 2);
+    
+    ASSERT_EQ(pedersenCalls.size(), 3);
+    auto& el = pedersenCalls[0];
+    ASSERT_EQ(el.size(), 508);
+    ASSERT_TRUE(std::equal(el.cbegin() + 506, el.cend(), inputV.cbegin()));
+
+    el = pedersenCalls[1];
+    ASSERT_EQ(el.size(), 508);
+    ASSERT_TRUE(std::equal(el.cbegin() + 506, el.cend(), inputV.cbegin() + 2));
+
+    el = pedersenCalls[2];
+    ASSERT_EQ(el.size(), 508);
+    ASSERT_TRUE(std::equal(el.cbegin() + 506, el.cend(), inputV.cbegin() + 4));
+}
+
+int main(int argc, char **argv) {
+    testing::FLAGS_gtest_death_test_style = "threadsafe";
+    testing::InitGoogleTest(&argc, argv);
+    return RUN_ALL_TESTS();
+}

--- a/pepper/test/apps/util.h
+++ b/pepper/test/apps/util.h
@@ -1,3 +1,7 @@
+#ifndef ORDERS
+#define ORDERS 1
+#endif
+
 namespace pepper_overrides
 {
     /**
@@ -35,6 +39,7 @@ namespace pepper_overrides
     }
 } // pepper_overrides
 
+#ifndef EXT_GADGET_OVERRIDE
 void ext_gadget(void* in, void* out, uint32_t gadget) {
     switch(gadget) {
         case 0:
@@ -47,7 +52,9 @@ void ext_gadget(void* in, void* out, uint32_t gadget) {
             FAIL();
     }
 }
+#endif
 
+#ifndef EXO_COMPUT_OVERRIDE
 void exo_compute(uint32_t** input, uint32_t* length, void* output, uint32_t exo) {
     switch(exo) {
         case 0:
@@ -60,7 +67,10 @@ void exo_compute(uint32_t** input, uint32_t* length, void* output, uint32_t exo)
             FAIL();
     }
 }
+#endif
 
+#ifndef ASSERT_ZERO_OVERRIDE
 void assert_zero(uint32_t v) {
     assert(0 == v);
 }
+#endif


### PR DESCRIPTION
Since we will create chains of pedersen hashes in the main snark as well, it makes sense to pull it into its own method (separate file which will host a similar method for SHA chaining and SHA merkle tree as well).

Made sure we are not increasing total amount of constraints and added a unit test.