### PR TITLE
Do not print last witness twice

### DIFF
--- a/pepper/scripts/pepper_binary_format_reader.cpp
+++ b/pepper/scripts/pepper_binary_format_reader.cpp
@@ -34,7 +34,7 @@ int main(int argc, char **argv)
             std::cout << index / PROGRESS_INTERVAL << PROGRESS_UNIT << " constraints \n";
         }
 
-    } while (source.get() > 0);
+    } while (source.get() > 0 && (source.peek() != EOF));
 
     source.close();
     fclose(target);


### PR DESCRIPTION
The exported pepper file seems to end with a space and thus we enter the while loop one last time when we have parsed all values but before we reach EOF.

This has lead to printing the last witness variable twice and resulted in one too many variables, causing subsequent solvers to fail.

By peeking into the buffer and checking that the next character is not EOF, we can avoid this.