### PR TITLE
Making PH Gadget return result

### DIFF
--- a/pepper/apps/hashing.h
+++ b/pepper/apps/hashing.h
@@ -1,7 +1,7 @@
 #include <stdint.h>
 #include "dex_common.h"
 
-#define PEDERSEN_HASH_SIZE 508
+#define PEDERSEN_HASH_SIZE 510 //PH gadget requires len % 3 = 0
 #define SHA_HASH_SIZE 512
 
 /**

--- a/pepper/ext_gadget/pedersen_bridge.cpp
+++ b/pepper/ext_gadget/pedersen_bridge.cpp
@@ -1,14 +1,15 @@
 #include "common.h"
 #include "jubjub/pedersen_hash.hpp"
 #include "jubjub/params.hpp"
+#include "utils.hpp"
 
 using namespace libsnark;
 using namespace libff;
 
 #define BUFLEN 10240
 
-#define LEFT_INPUT_SIZE 254
-#define RIGHT_INPUT_SIZE 254
+#define LEFT_INPUT_SIZE 255
+#define RIGHT_INPUT_SIZE 255
 #define OUTPUT_SIZE 2
 
 uint64_t inputSize() {
@@ -27,26 +28,32 @@ protoboard<FieldT> getProtoboard(const char* assignment)
 
     ethsnarks::VariableArrayT in;
     // The gadget expects input that is a multiple of three. Thus, we pad with 0s.
-    size_t padding  = (3 - (inputSize() % 3)) % 3;
-    size_t scalar_size = inputSize() + padding;
-    in.allocate(pb, scalar_size, FMT("annotation_prefix", " scaler to multiply by"));
+    assert(inputSize() % 3 == 0);
+    in.allocate(pb, inputSize(), FMT("bridge", " scaler to multiply by"));
+
+    ethsnarks::VariableT result_x = ethsnarks::make_variable(pb, FMT("bridge", "result_x"));
+    ethsnarks::VariableT result_y = ethsnarks::make_variable(pb, FMT("bridge", "result_y"));
 
     ethsnarks::jubjub::PedersenHash f(pb, params, "dex.pedersen-hash", in, "gadget");
     f.generate_r1cs_constraints();
 
-    if (assignment) {
-	libff::bit_vector in_bv;
-     	for (int i = 0; i < scalar_size; i++) {
-            if (i < inputSize()) {
-                in_bv.push_back(assignment[2*i] - '0');
-            } else {
-                in_bv.push_back(false);
-            }
-    	}
+    pb.add_r1cs_constraint(
+        ethsnarks::ConstraintT(result_x, 1, f.result_x()),
+            FMT("bridge", "bridge.result_x=gadget.result_x"));
+    pb.add_r1cs_constraint(
+        ethsnarks::ConstraintT(result_y, 1, f.result_y()),
+            FMT("bridge", "bridge.result_y=gadget.result_y"));
 
-	in.fill_with_bits(pb, in_bv);
-     	f.generate_r1cs_witness();
-	assert(pb.is_satisfied());
+    if (assignment) {
+        libff::bit_vector in_bv;
+        for (int i = 0; i < inputSize(); i++) {
+            in_bv.push_back(assignment[2*i] - '0');
+        }
+        in.fill_with_bits(pb, in_bv);
+        f.generate_r1cs_witness();
+        pb.val(result_x) = pb.val(f.result_x());
+        pb.val(result_y) = pb.val(f.result_y());
+        assert(pb.is_satisfied());
     }
     
     return pb;

--- a/pepper/test/apps/hashing_test.cpp
+++ b/pepper/test/apps/hashing_test.cpp
@@ -46,6 +46,7 @@ void ext_gadget(void* in, void* out, uint32_t gadget) {
 
 #pragma mark - Pedersen
 
+#define PADDING 2
 TEST(HashPedersenTest, SingleChunk) { 
     pedersenCalls.clear();
     field254 input[6] = {0, 0, 0, 1, 1, 1};
@@ -55,7 +56,7 @@ TEST(HashPedersenTest, SingleChunk) {
 
     ASSERT_EQ(pedersenCalls.size(), 1);
     auto& first = pedersenCalls.front();
-    ASSERT_TRUE(std::equal(first.cbegin() + PEDERSEN_HASH_SIZE - 6, first.cend(), inputV.cbegin()));
+    ASSERT_TRUE(std::equal(first.cbegin() + PEDERSEN_HASH_SIZE - 6 - PADDING, first.cend() - PADDING, inputV.cbegin()));
 }
 
 TEST(HashPedersenTest, MultipleChunks) {
@@ -67,13 +68,13 @@ TEST(HashPedersenTest, MultipleChunks) {
     
     ASSERT_EQ(pedersenCalls.size(), 3);
     auto& el = pedersenCalls[0];
-    ASSERT_TRUE(std::equal(el.cbegin() + PEDERSEN_HASH_SIZE - 2, el.cend(), inputV.cbegin()));
+    ASSERT_TRUE(std::equal(el.cbegin() + PEDERSEN_HASH_SIZE - 2 - PADDING, el.cend() - PADDING, inputV.cbegin()));
 
     el = pedersenCalls[1];
-    ASSERT_TRUE(std::equal(el.cbegin() + PEDERSEN_HASH_SIZE - 2 , el.cend(), inputV.cbegin() + 2));
+    ASSERT_TRUE(std::equal(el.cbegin() + PEDERSEN_HASH_SIZE - 2 - PADDING, el.cend() - PADDING, inputV.cbegin() + 2));
 
     el = pedersenCalls[2];
-    ASSERT_TRUE(std::equal(el.cbegin() + PEDERSEN_HASH_SIZE - 2, el.cend(), inputV.cbegin() + 4));
+    ASSERT_TRUE(std::equal(el.cbegin() + PEDERSEN_HASH_SIZE - 2 - PADDING, el.cend() - PADDING, inputV.cbegin() + 4));
 }
 
 TEST(HashPedersenTest, ReusesXCoordinateInNextRound) {

--- a/pepper/test/e2e/hash_transform.sh
+++ b/pepper/test/e2e/hash_transform.sh
@@ -14,3 +14,5 @@ echo 032701115855630478187979287852631045544 >> prover_verifier_shared/transform
 
 ./bin/pepper_prover_hash_transform prove transform.pkey transform.inputs transform.outputs transform.proof
 ./bin/pepper_verifier_hash_transform verify transform.vkey transform.inputs transform.outputs transform.proof
+
+diff ./prover_verifier_shared/transform.outputs <(printf "0\n2709151994604095268253795983695773831904488672374264037853826788765176428835\n")


### PR DESCRIPTION
The PedersenHash Bridge was returning 0s as a result instead of correct values. The reason was that we currently assume the witness to be `INPUT1 ... INPUTN OUTPUT1 ... OUTPUTN AUX1 .. AUXN`. The Pedersen Gadget as provided by ethsnarks doesn't have this guarantee (I believe outputs are the last values in the witness). Moreover our bridge was padding the input with 0s to be divisable by 3 (requirement by the Pedersen Gadget), which lead to having 0 in the position we expected the result.

This diff
1) Improves the e2e test to catch such issues going forward
2) Introduces output variables at the right location inside the bridge and copies the gadget outputs into them (2 added constraints)
3) Moves the padding logic (divisable by 3) into the pepper snark, as the amount of input variables needs to be know ahead of time and cannot easily be changed from inside the bridge.