### PR TITLE
Avoid pointer arithmetic

### DIFF
--- a/pepper/apps/dex_common.h
+++ b/pepper/apps/dex_common.h
@@ -13,12 +13,12 @@ void copyBits(field254* source, uint32_t source_offset, field254* target, uint32
 /**
  * sums `length` bits from `bits` to its integer representation  
  */
-field254 sumBits(field254 *bits, uint32_t length) {
+field254 sumBits(field254 *bits, uint32_t offset, uint32_t length) {
     field254 result = 0;
     field254 pow = 1;
     uint32_t index = 0;
     for (index=0; index<length; index++) {
-        result += bits[length-1-index] * pow;
+        result += bits[offset+length-1-index] * pow;
         pow = pow * 2;
     }
     return result;
@@ -52,14 +52,14 @@ void isBoolVerification(field254 *bits, uint32_t length) {
  * Afterwards verify that bits sum up to number.
  */
 struct Decomposed { field254 bits[254]; };
-void decomposeBits(field254 number, field254* bits) {
+void decomposeBits(field254 number, field254* bits, uint32_t offset) {
     struct Decomposed result[1] = { 0 };
     uint32_t lens[1] = {1};
     field254 input[1] = {number};
     field254 *exo1_inputs[1] = { input };
     exo_compute(exo1_inputs,lens,result,1);
     isBoolVerification(result->bits, 254);
-    field254 sum = sumBits(result->bits, 254);
+    field254 sum = sumBits(result->bits, 0, 254);
     assert_zero(sum - number);
-	copyBits(result->bits, 0, bits, 0, 254);
+	copyBits(result->bits, 0, bits, offset, 254);
 }

--- a/pepper/apps/dex_common.h
+++ b/pepper/apps/dex_common.h
@@ -61,5 +61,5 @@ void decomposeBits(field254 number, field254* bits, uint32_t offset) {
     isBoolVerification(result->bits, 254);
     field254 sum = sumBits(result->bits, 0, 254);
     assert_zero(sum - number);
-	copyBits(result->bits, 0, bits, offset, 254);
+    copyBits(result->bits, 0, bits, offset, 254);
 }

--- a/pepper/apps/hash_transform.c
+++ b/pepper/apps/hash_transform.c
@@ -4,10 +4,10 @@
 void compute(struct In *input, struct Out *output){
     // Read private input
     struct Private pInput = readPrivateInput();   
-    struct ShaResult result = hashSHA(pInput.orders, ORDERS*253, 253);
+    struct ShaResult result = hashSHA(pInput.orders, 0, ORDERS*253, 253);
 
     assert_zero(result.left - input->shaHashL);
     assert_zero(result.right - input->shaHashR);
 
-    output->pedersenHash = hashPedersen(pInput.orders, ORDERS*253, 253);
+    output->pedersenHash = hashPedersen(pInput.orders, 0, ORDERS*253, 253);
 }

--- a/pepper/apps/hashing.h
+++ b/pepper/apps/hashing.h
@@ -12,19 +12,19 @@
  * E.g. hashPedersen([0,0,1,1], 4, 2) == hash(hash(O, [0,0]), [1,1])
  */
 struct PedersenHash { field254 values[2]; }; /* resulting Point(x,y) */
-field254 hashPedersen(field254 *in, uint32_t inputSize, uint32_t chunkSize) {
+field254 hashPedersen(field254 *in, uint32_t offset, uint32_t inputSize, uint32_t chunkSize) {
     struct PedersenHash result[1] = { 0 };
     uint32_t index;
     for (index = 0; index < inputSize; index += chunkSize) {
         // Decompose x-coordinate from previous result to binary
         field254 decomposed[254] = { 0 };
-        decomposeBits(result->values[0], decomposed);
+        decomposeBits(result->values[0], decomposed, offset);
 
         // Fill pedersen input, left with previous result
         field254 pedersenInput[PEDERSEN_HASH_SIZE] = { 0 };
         copyBits(decomposed, 0, pedersenInput, 0, 254);
         uint32_t padding = 254 - chunkSize;
-        copyBits(in, index, pedersenInput, 254+padding, chunkSize);
+        copyBits(in, offset + index, pedersenInput, 254+padding, chunkSize);
 
         ext_gadget(pedersenInput, result, 1);
     }
@@ -37,7 +37,7 @@ field254 hashPedersen(field254 *in, uint32_t inputSize, uint32_t chunkSize) {
  */
 struct ShaHash { field254 digest[256]; };
 struct ShaResult { field254 left; field254 right; };
-struct ShaResult hashSHA(field254 *in, uint32_t inputSize, uint32_t chunkSize) {
+struct ShaResult hashSHA(field254 *in, uint32_t offset, uint32_t inputSize, uint32_t chunkSize) {
     struct ShaHash shaOut[1] = { 0 };
 
     field254 shaIn[SHA_HASH_SIZE] = { 0 };
@@ -46,13 +46,13 @@ struct ShaResult hashSHA(field254 *in, uint32_t inputSize, uint32_t chunkSize) {
         // sha hash
         copyBits(shaOut->digest, 0, shaIn, 0, 256);
         uint32_t padding = 256 - chunkSize;
-        copyBits(in, index, shaIn, 256 + padding, chunkSize);
+        copyBits(in, offset + index, shaIn, 256 + padding, chunkSize);
         ext_gadget(shaIn, shaOut, 0);
     }
 
     struct ShaResult result = {
-        sumBits(shaOut->digest, 128),
-        sumBits(shaOut->digest+128, 128)
+        sumBits(shaOut->digest, 0, 128),
+        sumBits(shaOut->digest, 128, 128)
     };
     return result;
 }

--- a/pepper/test/apps/hashing_test.cpp
+++ b/pepper/test/apps/hashing_test.cpp
@@ -52,7 +52,7 @@ TEST(HashPedersenTest, SingleChunk) {
     field254 input[6] = {0, 0, 0, 1, 1, 1};
     std::vector<field254> inputV(input, input+6);
 
-    hashPedersen(input, 6, 6);
+    hashPedersen(input, 0, 6, 6);
 
     ASSERT_EQ(pedersenCalls.size(), 1);
     auto& first = pedersenCalls.front();
@@ -64,7 +64,25 @@ TEST(HashPedersenTest, MultipleChunks) {
     field254 input[6] = {0, 0, 0, 1, 1, 1};
     std::vector<field254> inputV(input, input+6);
     
-    hashPedersen(input, 6, 2);
+    hashPedersen(input, 0, 6, 2);
+    
+    ASSERT_EQ(pedersenCalls.size(), 3);
+    auto& el = pedersenCalls[0];
+    ASSERT_TRUE(std::equal(el.cbegin() + PEDERSEN_HASH_SIZE - 2 - PADDING, el.cend() - PADDING, inputV.cbegin()));
+
+    el = pedersenCalls[1];
+    ASSERT_TRUE(std::equal(el.cbegin() + PEDERSEN_HASH_SIZE - 2 - PADDING, el.cend() - PADDING, inputV.cbegin() + 2));
+
+    el = pedersenCalls[2];
+    ASSERT_TRUE(std::equal(el.cbegin() + PEDERSEN_HASH_SIZE - 2 - PADDING, el.cend() - PADDING, inputV.cbegin() + 4));
+}
+
+TEST(HashPedersenTest, MultipleChunksOffset) {
+    pedersenCalls.clear();
+    field254 input[7] = {42, 0, 0, 0, 1, 1, 1};
+    std::vector<field254> inputV(input+1, input+7);
+    
+    hashPedersen(input, 1, 6, 2);
     
     ASSERT_EQ(pedersenCalls.size(), 3);
     auto& el = pedersenCalls[0];
@@ -82,7 +100,7 @@ TEST(HashPedersenTest, ReusesXCoordinateInNextRound) {
     pedersenHashResult = { {1, 0} };
     field254 input[6] = {0};
     
-    auto result = hashPedersen(input, 6, 3);
+    auto result = hashPedersen(input, 0, 6, 3);
     ASSERT_EQ(pedersenCalls.size(), 2);
 
     // Result is X Coordinate
@@ -103,7 +121,7 @@ TEST(HashSHATest, SingleChunk) {
     shaCalls.clear();
     field254 input[6] = {0, 0, 0, 1, 1, 1};
     std::vector<field254> inputV(input, input+6);
-    hashSHA(input, 6, 6);
+    hashSHA(input, 0, 6, 6);
 
     ASSERT_EQ(shaCalls.size(), 1);
     auto& first = shaCalls.front();
@@ -115,7 +133,25 @@ TEST(HashSHATest, MultipleChunks) {
     field254 input[6] = {0, 0, 0, 1, 1, 1};
     std::vector<field254> inputV(input, input+6);
 
-    hashSHA(input, 6, 2);
+    hashSHA(input, 0, 6, 2);
+
+    ASSERT_EQ(shaCalls.size(), 3);
+    auto& el = shaCalls[0];
+    ASSERT_TRUE(std::equal(el.cbegin() + SHA_HASH_SIZE - 2, el.cend(), inputV.cbegin()));
+
+    el = shaCalls[1];
+    ASSERT_TRUE(std::equal(el.cbegin() + SHA_HASH_SIZE - 2, el.cend(), inputV.cbegin() + 2));
+
+    el = shaCalls[2];
+    ASSERT_TRUE(std::equal(el.cbegin() + SHA_HASH_SIZE - 2, el.cend(), inputV.cbegin() + 4));
+}
+
+TEST(HashSHATest, MultipleChunksOffset) { 
+    shaCalls.clear();
+    field254 input[7] = {42, 0, 0, 0, 1, 1, 1};
+    std::vector<field254> inputV(input+1, input+7);
+
+    hashSHA(input, 1, 6, 2);
 
     ASSERT_EQ(shaCalls.size(), 3);
     auto& el = shaCalls[0];
@@ -134,7 +170,7 @@ TEST(HashSHATest, ReuseResultInNextRound) {
     shaResult.digest[255] = 1;
 
     field254 input[6] = { 0 };
-    hashSHA(input, 6, 3);
+    hashSHA(input, 0, 6, 3);
 
     ASSERT_EQ(pedersenCalls.size(), 2);
     
@@ -156,7 +192,7 @@ TEST(HashSHATest, SplitsResult) {
     shaResult.digest[255] = 1;
 
     field254 input[6] = { 0 };
-    ShaResult result = hashSHA(input, 6, 6);
+    ShaResult result = hashSHA(input, 0, 6, 6);
 
     ASSERT_EQ(result.left, 1);
     ASSERT_EQ(result.right, 3);

--- a/pepper/test/apps/util.h
+++ b/pepper/test/apps/util.h
@@ -31,14 +31,14 @@ namespace pepper_overrides
         }
     }
 
-    void decomposeBits(field254 number, field254 bits[254]) {
+    void decomposeBits(field254 number, field254* bits, uint32_t offset) {
         int index = 0;
         unsigned long nr = number.as_ulong();
         while (nr > 0) {
             if(nr%2==0)
-                bits[253 - index] = field254::zero();
+                bits[offset + 253 - index] = field254::zero();
             else
-                bits[253 - index] = field254::one();
+                bits[offset + 253 - index] = field254::one();
             nr = nr/2;
         }
     }
@@ -66,7 +66,7 @@ void exo_compute(field254** input, uint32_t* length, void* output, uint32_t exo)
             pepper_overrides::privateInput(output);
             break;
         case 1:
-            pepper_overrides::decomposeBits(input[0][0],((Decomposed*) output)->bits);
+            pepper_overrides::decomposeBits(input[0][0],((Decomposed*) output)->bits, 0);
             break;
         default:
             FAIL();


### PR DESCRIPTION
Remove pointer arithmetic (e.g`(bit*)foo + 3`). Instead, pass along the offset (in the example that would be 3) and only use it when a single item is accessed (e.g. `foo[i] --> foo[offset + i]`).

The reason for that is that pointer arithmetic leads to a constraint explosion in pepper and thus needs to be avoided. For more background see https://github.com/pepper-project/pequin/issues/35.