### PR TITLE
Small changes to the way we do unit testing

### DIFF
--- a/pepper/Dockerfile
+++ b/pepper/Dockerfile
@@ -4,7 +4,14 @@ MAINTAINER Felix Leupold <felix@gnosis.pm>
 ENV PEPPER /home/docker/pequin
 
 USER root
-RUN apt-get install -y inotify-tools libgtest-dev time vim tmux
+RUN apt-get install -y inotify-tools libgtest-dev time vim tmux software-properties-common
+
+# Upgrade Boost
+RUN apt-get remove -y libboost1.54-dev
+RUN add-apt-repository -y ppa:mhier/libboost-latest
+RUN apt-get update -y
+RUN apt-get install -y libboost1.67-dev
+
 RUN cd /usr/src/gtest && cmake CMakeLists.txt && make && cp *.a /usr/lib
 
 USER docker

--- a/pepper/Makefile
+++ b/pepper/Makefile
@@ -9,7 +9,7 @@ IFLAGS = -Iext_gadget -I$(LIBSNARK)/ -I$(LIBSNARK)/depends/libff -I$(LIBSNARK)/d
 LDFLAGS = -L$(LIBSNARK)/build/libsnark -L$(LIBSNARK)/build/depends/libff/libff
 LDFLAGS += -lsnark -lff -lgmp -lgmpxx
 
-TEST_LDFLAGS = -lgtest -lpthread
+TEST_LDFLAGS = -lgtest -lpthread -lboost_stacktrace_backtrace -DBOOST_STACKTRACE_USE_BACKTRACE -ldl
 TEST_IFLAGS = -I./
 TEST_BIN = test/bin/
 
@@ -53,7 +53,7 @@ e2e-tests: check-env
 unit-tests: $(patsubst test/apps/%.cpp, app_%, $(wildcard test/apps/*_test.cpp))
 
 app_%_test: test/apps/%_test.cpp
-	$(CXX) $(CXXFLAGS) -DTEST $(TEST_IFLAGS) $(IFLAGS) $< -o $(TEST_BIN)/$@ $(TEST_LDFLAGS) $(LDFLAGS) 
+	$(CXX) -g $(CXXFLAGS) -DTEST $(TEST_IFLAGS) $(IFLAGS) $< -o $(TEST_BIN)/$@ $(TEST_LDFLAGS) $(LDFLAGS) 
 	$(TEST_BIN)/$@
 
 gadget-tests: test/gadgets/main.cpp

--- a/pepper/apps/dex_common.h
+++ b/pepper/apps/dex_common.h
@@ -61,13 +61,5 @@ void decomposeBits(field254 number, field254* bits, uint32_t offset, uint32_t si
     isBoolVerification(result->bits, 254);
     field254 sum = sumBits(result->bits, 0, 254);
     assert_zero(sum - number);
-	copyBits(result->bits, 254-size, bits, offset, size);
-}
-
-uint32_t fieldToInt(field254 field) {
-#ifndef TEST
-    return field;
-#else
-    return field.as_ulong();
-#endif
+    copyBits(result->bits, 254-size, bits, offset, size);
 }

--- a/pepper/apps/dex_common.h
+++ b/pepper/apps/dex_common.h
@@ -52,7 +52,7 @@ void isBoolVerification(field254 *bits, uint32_t length) {
  * Afterwards verify that bits sum up to number.
  */
 struct Decomposed { field254 bits[254]; };
-void decomposeBits(field254 number, field254* bits, uint32_t offset) {
+void decomposeBits(field254 number, field254* bits, uint32_t offset, uint32_t size) {
     struct Decomposed result[1] = { 0 };
     uint32_t lens[1] = {1};
     field254 input[1] = {number};
@@ -61,5 +61,13 @@ void decomposeBits(field254 number, field254* bits, uint32_t offset) {
     isBoolVerification(result->bits, 254);
     field254 sum = sumBits(result->bits, 0, 254);
     assert_zero(sum - number);
-    copyBits(result->bits, 0, bits, offset, 254);
+	copyBits(result->bits, 254-size, bits, offset, size);
+}
+
+uint32_t fieldToInt(field254 field) {
+#ifndef TEST
+    return field;
+#else
+    return field.as_ulong();
+#endif
 }

--- a/pepper/apps/hashing.h
+++ b/pepper/apps/hashing.h
@@ -17,12 +17,9 @@ field254 hashPedersen(field254 *in, uint32_t offset, uint32_t inputSize, uint32_
     uint32_t index;
     for (index = 0; index < inputSize; index += chunkSize) {
         // Decompose x-coordinate from previous result to binary
-        field254 decomposed[254] = { 0 };
-        decomposeBits(result->values[0], decomposed, offset);
-
         // Fill pedersen input, left with previous result
         field254 pedersenInput[PEDERSEN_HASH_SIZE] = { 0 };
-        copyBits(decomposed, 0, pedersenInput, 0, 254);
+        decomposeBits(result->values[0], pedersenInput, 0, 254);
         uint32_t padding = 254 - chunkSize;
         copyBits(in, offset + index, pedersenInput, 254+padding, chunkSize);
 

--- a/pepper/test/apps/hash_transform_test.cpp
+++ b/pepper/test/apps/hash_transform_test.cpp
@@ -8,17 +8,23 @@
 #include "util.h"
 
 TEST(HashTransformTest, TransformWithMatchingSHA) { 
-    pepper_overrides::shaCount = 0;
-    struct In input = { 0,3 }; /* resulting SHA after two rounds will be 11 */
+    privateInput = { {0} };
+    ShaResult shaHash = hashSHA(privateInput.orders, 0, ORDERS*253, 253);
+    field254 pedersenHash = hashPedersen(privateInput.orders, 0, ORDERS*253, 253);
+
+    struct In input = { shaHash.left, shaHash.right };
     struct Out output;
     compute(&input, &output);
-    ASSERT_EQ(output.pedersenHash, 2);
+    ASSERT_EQ(output.pedersenHash, pedersenHash);
 }
 
 TEST(HashTransformTest, TransformWithWrongSHA) {
     struct In input = { 5 };
     struct Out output;
+
+    DISABLE_STACKTRACE = true;
     ASSERT_DEATH(compute(&input, &output), "");
+    DISABLE_STACKTRACE = false;
 }
  
 int main(int argc, char **argv) {

--- a/pepper/test/apps/isBoolVerification_test.cpp
+++ b/pepper/test/apps/isBoolVerification_test.cpp
@@ -22,7 +22,10 @@ TEST(isBoolVerification, isBoolVerificationWithNonbools) {
     field254 bits[2] = { 0 };
     bits[0] = field254("2");
     bits[1] = field254("0");
+
+    DISABLE_STACKTRACE = true;
     ASSERT_DEATH(isBoolVerification(bits, length), "");
+    DISABLE_STACKTRACE = false;
 }
 
 int main(int argc, char **argv) {

--- a/pepper/test/apps/util.h
+++ b/pepper/test/apps/util.h
@@ -7,7 +7,7 @@
 namespace pepper_overrides
 {
     /**
-     * Dummy pedersen implementation: xor pairs
+     * Dummy pedersen implementation: XOR lhs and rhs bits
      */
     void sha(field254 in[SHA_HASH_SIZE], field254 out[256]) {
         for (size_t index = 0; index < 256; index++) {
@@ -16,7 +16,7 @@ namespace pepper_overrides
     }
 
     /**
-     * Dummy pedersen implementation: sum of all inputs
+     * Dummy pedersen implementation: Sum of all inputs
      */
     void pedersen(field254 in[PEDERSEN_HASH_SIZE], field254 out[2]) {
         for (size_t index = 0; index < PEDERSEN_HASH_SIZE; index++) {


### PR DESCRIPTION
A few changes merged into this one small PR (not great, but each one of them would be hard to separate out):
1) We can now print stacktraces when our assert_zero fails. This is helpful to debug, which assertion specifically is failing (e.g. if three hashes are checked, we know immediately which one is wrong). This requires depending on Boost and compiling without optimizations.
2) Remove side-effects of hashfunction implementations in test: Before, calling hashPedersen on the same input twice, would result in different outputs. This is not great for the main snark, since we do multiple pedersenHashes in the same function and want the same data to have the same result. It's still using a dummy iplementation, but at least without sideeffects now. We might later want to implement a proper hash function there.
3) Provide global privateInput: For the hashTransform we just passed 0s as privateInput. In order to write meaningful tests for the main snark we need a way to control our input. I therefore added a global variable that can be assigned from within each test case to provide specific private input.
4) Adding an offset to `decomposeBits`: This is particularly useful for deserializing balances/prices (#13) , but already for `hashPedersen` it gets rid of one copy assignment (saving constraints)