### PR TITLE
Adding rounding to trade execution snark

### DIFF
--- a/pepper/apps/trade_execution.c
+++ b/pepper/apps/trade_execution.c
@@ -3,6 +3,8 @@
 #include "parsing.h"
 #include "hashing.h"
 
+static const field254 EPSILON = 100;
+
 void compute(struct In *input, struct Out *output) {
     struct Private pInput = readPrivateInput();
     // We need a way of faling an assert (e.g. assert_zero(1)).
@@ -64,9 +66,12 @@ void compute(struct In *input, struct Out *output) {
         sellVolumes[fieldToInt(order.sellToken)] += volume.sellVolume;
     }
 
-    // check that buyVolume == sellVolume for each token
+    // check that buyVolume ≈≈ sellVolume for each token, sellVolume cannot be smaller
     for (index=0; index < TOKENS; index++) {
-        assert_zero(buyVolumes[index] - sellVolumes[index]);
+        if (isNegative(sellVolumes[index] - buyVolumes[index]) 
+            || isNegative(EPSILON + buyVolumes[index] - sellVolumes[index])) {
+            assert_zero(input->one);
+        }
     }
     assert_zero(totalSurplus - input->surplus);
 

--- a/pepper/apps/trade_execution.c
+++ b/pepper/apps/trade_execution.c
@@ -3,13 +3,9 @@
 #include "parsing.h"
 #include "hashing.h"
 
-static const field254 EPSILON = 100;
-
 void compute(struct In *input, struct Out *output) {
+    static const field254 EPSILON = 100;
     struct Private pInput = readPrivateInput();
-    // We need a way of faling an assert (e.g. assert_zero(1)).
-    // Hardcoding the one in code doesn't compile, so we have to pass and verify it.
-    assert_zero(input->one - 1);
 
     // Assert that private input matches public
     // Step 1: Balances (PedersenHash)
@@ -46,16 +42,18 @@ void compute(struct In *input, struct Out *output) {
         struct Volume volume = volumes[index];
         
         if (fieldToInt(volume.sellVolume) > 0) {
-            // Verify volume has same ratio as prices
-            assert_zero((volume.buyVolume * prices[fieldToInt(order.buyToken)]) - (volume.sellVolume * prices[fieldToInt(order.sellToken)]));
+            // Verify volume has roughly same ratio as prices
+            field254 priceVolumeDelta = (volume.buyVolume * prices[fieldToInt(order.buyToken)]) - (volume.sellVolume * prices[fieldToInt(order.sellToken)]);
+            // Make sure |delta| < epsilon
+            assert_zero(isNegative(EPSILON - priceVolumeDelta) || isNegative(EPSILON + priceVolumeDelta));
 
             // Limit price compliance
-            if (fieldToInt(volume.buyVolume * order.sellAmount) < fieldToInt(volume.sellVolume * order.buyAmount) || isNegative(order.sellAmount - volume.sellVolume)) {
-                assert_zero(input->one);
-            }
+            assert_zero(isNegative(fieldToInt(volume.sellVolume * order.buyAmount) - fieldToInt(volume.buyVolume * order.sellAmount)));
+            // Limit amount compliance
+            assert_zero(isNegative(order.sellAmount - volume.sellVolume));
 
             // Verify surplus
-            assert_zero((((volume.buyVolume * order.sellAmount) - (volume.sellVolume * order.buyAmount)) * prices[fieldToInt(order.buyToken)]) - (volume.surplus * order.sellAmount));
+            assert_zero(isNegative((((volume.buyVolume * order.sellAmount) - (volume.sellVolume * order.buyAmount)) * prices[fieldToInt(order.buyToken)]) - (volume.surplus * order.sellAmount)));
             totalSurplus += volume.surplus;
         }
         
@@ -68,10 +66,8 @@ void compute(struct In *input, struct Out *output) {
 
     // check that buyVolume ≈≈ sellVolume for each token, sellVolume cannot be smaller
     for (index=0; index < TOKENS; index++) {
-        if (isNegative(sellVolumes[index] - buyVolumes[index]) 
-            || isNegative(EPSILON + buyVolumes[index] - sellVolumes[index])) {
-            assert_zero(input->one);
-        }
+        assert_zero(isNegative(sellVolumes[index] - buyVolumes[index])); 
+        assert_zero(isNegative(EPSILON + buyVolumes[index] - sellVolumes[index]));
     }
     assert_zero(totalSurplus - input->surplus);
 

--- a/pepper/apps/trade_execution.h
+++ b/pepper/apps/trade_execution.h
@@ -19,7 +19,6 @@ struct In {
     field254 surplus;
     field254 hashBatchInfo[2];
     field254 orderHash;
-    field254 one;
 };
 
 struct Out { field254 state; };

--- a/pepper/test/apps/trade_execution_test.cpp
+++ b/pepper/test/apps/trade_execution_test.cpp
@@ -533,7 +533,7 @@ TEST(TradeExecutionTest, PriceDoesntMatchVolume) {
     DISABLE_STACKTRACE = false;
 }
 
-TEST(TradeExecutionTest, BuyVolumeSlightlyGreateSellVolume) {
+TEST(TradeExecutionTest, BuyVolumeSlightlyGreaterSellVolume) {
     struct Balance balances[ACCOUNTS] = {0};
     struct Order orders[ORDERS] = {0};
     struct Volume volumes[ORDERS] = {0};


### PR DESCRIPTION
Before, the trade execution snark is expecting values to match exactly. In particular, the relations between buy/sell volume and prices, the total sum of tokens bought/sold as well as the trader surplus where exact equalities.

As sketched out in #14 this limits the region of valid solutions drastically. Therefore, we are introducing an epsilon (and unit tests to show which kind of values are now variable) to allow ≈ instead of =.