### PR TITLE
Modeling balances as single array instead of array as structs

### DIFF
--- a/pepper/apps/parsing.h
+++ b/pepper/apps/parsing.h
@@ -10,10 +10,6 @@ struct Order {
     field254 buyAmount;
 };
 
-struct Balance {
-    field254 token[TOKENS];
-};
-
 struct Volume {
     field254 sellVolume;
     field254 buyVolume;
@@ -66,22 +62,22 @@ void serializeOrders(struct Order orders[ORDERS], field254 *serialized, uint32_t
     }
 }
 
-void parseBalances(field254 *bits, uint32_t offset, struct Balance balances[ACCOUNTS]) {
+void parseBalances(field254 *bits, uint32_t offset, field254 balances[ACCOUNTS*TOKENS]) {
     uint32_t accountIndex, tokenIndex = 0;
     for (accountIndex = 0; accountIndex < ACCOUNTS; accountIndex++) {
         for (tokenIndex = 0; tokenIndex < TOKENS; tokenIndex++) {
             uint32_t balanceOffset = offset + (BITS_PER_DECIMAL * (accountIndex * TOKENS + tokenIndex));
-            balances[accountIndex].token[tokenIndex] = parseDecimal(bits, balanceOffset);
+            balances[(accountIndex*TOKENS) + tokenIndex] = parseDecimal(bits, balanceOffset);
         }
     }
 }
 
-void serializeBalances(struct Balance balances[ACCOUNTS], field254* serialized, uint32_t offset) {
+void serializeBalances(field254 balances[TOKENS*ACCOUNTS], field254* serialized, uint32_t offset) {
     uint32_t accountIndex, tokenIndex = 0;
     for (accountIndex = 0; accountIndex < ACCOUNTS; accountIndex++) {
         for (tokenIndex = 0; tokenIndex < TOKENS; tokenIndex++) {
             uint32_t balanceOffset = offset + (BITS_PER_DECIMAL * (accountIndex * TOKENS + tokenIndex));
-            decomposeBits(balances[accountIndex].token[tokenIndex], serialized, balanceOffset, BITS_PER_DECIMAL);
+            decomposeBits(balances[(accountIndex * TOKENS) + tokenIndex], serialized, balanceOffset, BITS_PER_DECIMAL);
         }
     }
 }

--- a/pepper/apps/trade_execution.c
+++ b/pepper/apps/trade_execution.c
@@ -3,6 +3,8 @@
 #include "parsing.h"
 #include "hashing.h"
 
+static const field254 EPSILON = 100;
+
 void compute(struct In *input, struct Out *output) {
     struct Private pInput = readPrivateInput();
     // We need a way of faling an assert (e.g. assert_zero(1)).
@@ -64,9 +66,12 @@ void compute(struct In *input, struct Out *output) {
         sellVolumes[fieldToInt(order.sellToken)] += volume.sellVolume;
     }
 
-    // check that buyVolume == sellVolume for each token
+    // check that buyVolume ≈≈ sellVolume for each token, sellVolume cannot be smaller
     for (index=0; index < TOKENS; index++) {
-        assert_zero(buyVolumes[index] - sellVolumes[index]);
+        if (isNegative(sellVolumes[index] - buyVolumes[index]) 
+            || isNegative(EPSILON + buyVolumes[index] - sellVolumes[index])) {
+            assert_zero(input->one);
+        }
     }
     assert_zero(totalSurplus - input->surplus);
 

--- a/pepper/apps/trade_execution.c
+++ b/pepper/apps/trade_execution.c
@@ -3,13 +3,9 @@
 #include "parsing.h"
 #include "hashing.h"
 
-static const field254 EPSILON = 100;
-
 void compute(struct In *input, struct Out *output) {
+    static const field254 EPSILON = 100;
     struct Private pInput = readPrivateInput();
-    // We need a way of faling an assert (e.g. assert_zero(1)).
-    // Hardcoding the one in code doesn't compile, so we have to pass and verify it.
-    assert_zero(input->one - 1);
 
     // Assert that private input matches public
     // Step 1: Balances (PedersenHash)
@@ -46,16 +42,18 @@ void compute(struct In *input, struct Out *output) {
         struct Volume volume = volumes[index];
         
         if (fieldToInt(volume.sellVolume) > 0) {
-            // Verify volume has same ratio as prices
-            assert_zero((volume.buyVolume * prices[fieldToInt(order.buyToken)]) - (volume.sellVolume * prices[fieldToInt(order.sellToken)]));
+            // Verify volume has roughly same ratio as prices
+            field254 priceVolumeDelta = (volume.buyVolume * prices[fieldToInt(order.buyToken)]) - (volume.sellVolume * prices[fieldToInt(order.sellToken)]);
+            // Make sure |delta| < epsilon
+            assert_zero(isNegative(EPSILON - priceVolumeDelta) || isNegative(EPSILON + priceVolumeDelta));
 
             // Limit price compliance
-            if (fieldToInt(volume.buyVolume * order.sellAmount) < fieldToInt(volume.sellVolume * order.buyAmount) || isNegative(order.sellAmount - volume.sellVolume)) {
-                assert_zero(input->one);
-            }
+            assert_zero(isNegative(fieldToInt(volume.sellVolume * order.buyAmount) - fieldToInt(volume.buyVolume * order.sellAmount)));
+            // Limit amount compliance
+            assert_zero(isNegative(order.sellAmount - volume.sellVolume));
 
             // Verify surplus
-            assert_zero((((volume.buyVolume * order.sellAmount) - (volume.sellVolume * order.buyAmount)) * prices[fieldToInt(order.buyToken)]) - (volume.surplus * order.sellAmount));
+            assert_zero(isNegative((((volume.buyVolume * order.sellAmount) - (volume.sellVolume * order.buyAmount)) * prices[fieldToInt(order.buyToken)]) - (volume.surplus * order.sellAmount)));
             totalSurplus += volume.surplus;
         }
         
@@ -68,10 +66,8 @@ void compute(struct In *input, struct Out *output) {
 
     // check that buyVolume ≈≈ sellVolume for each token, sellVolume cannot be smaller
     for (index=0; index < TOKENS; index++) {
-        if (isNegative(sellVolumes[index] - buyVolumes[index]) 
-            || isNegative(EPSILON + buyVolumes[index] - sellVolumes[index])) {
-            assert_zero(input->one);
-        }
+        assert_zero(isNegative(sellVolumes[index] - buyVolumes[index])); 
+        assert_zero(isNegative(EPSILON + buyVolumes[index] - sellVolumes[index]));
     }
     assert_zero(totalSurplus - input->surplus);
 

--- a/pepper/apps/trade_execution.c
+++ b/pepper/apps/trade_execution.c
@@ -23,7 +23,7 @@ void compute(struct In *input, struct Out *output) {
     // Parse all private input
     struct Order orders[ORDERS] = {0};
     parseOrders(pInput.orders, 0, orders);
-    struct Balance balances[ACCOUNTS] = {0};
+    field254 balances[ACCOUNTS*TOKENS] = {0};
     parseBalances(pInput.balances, 0, balances);
     field254 prices[TOKENS] = {0};
     parsePrices(pInput.pricesAndVolumes, 0, prices);
@@ -41,29 +41,28 @@ void compute(struct In *input, struct Out *output) {
         struct Order order = orders[index];
         struct Volume volume = volumes[index];
         
-        if (fieldToInt(volume.sellVolume) > 0) {
-            // Verify volume has roughly same ratio as prices
-            field254 priceVolumeDelta = (volume.buyVolume * prices[fieldToInt(order.buyToken)]) - (volume.sellVolume * prices[fieldToInt(order.sellToken)]);
-            // Make sure |delta| < epsilon
-            assert_zero(isNegative(EPSILON - priceVolumeDelta) || isNegative(EPSILON + priceVolumeDelta));
+        // Verify volume has roughly same ratio as prices
+        field254 lhs = volume.buyVolume * prices[fieldToInt(order.buyToken)];
+        field254 rhs = volume.sellVolume * prices[fieldToInt(order.sellToken)];
+        field254 delta = lhs - rhs;
+        // Make sure |delta| < epsilon
+        assert_zero(isNegative((EPSILON*EPSILON) - delta) || isNegative((EPSILON*EPSILON) + delta));
 
-            // Limit price compliance
-            assert_zero(isNegative(fieldToInt(volume.sellVolume * order.buyAmount) - fieldToInt(volume.buyVolume * order.sellAmount)));
-            // Limit amount compliance
-            assert_zero(isNegative(order.sellAmount - volume.sellVolume));
+        // Limit price compliance
+        assert_zero(isNegative(fieldToInt(volume.sellVolume * order.buyAmount) - fieldToInt(volume.buyVolume * order.sellAmount)));
+        // Limit amount compliance
+        assert_zero(isNegative(order.sellAmount - volume.sellVolume));
 
-            // Verify surplus
-            assert_zero(isNegative((((volume.buyVolume * order.sellAmount) - (volume.sellVolume * order.buyAmount)) * prices[fieldToInt(order.buyToken)]) - (volume.surplus * order.sellAmount)));
-            totalSurplus += volume.surplus;
-        }
+        // Verify surplus
+        assert_zero(isNegative((((volume.buyVolume * order.sellAmount) - (volume.sellVolume * order.buyAmount)) * prices[fieldToInt(order.buyToken)]) - (volume.surplus * order.sellAmount)));
+        totalSurplus += volume.surplus;
         
-        balances[fieldToInt(order.account)].token[fieldToInt(order.sellToken)] -= volume.sellVolume;
-        balances[fieldToInt(order.account)].token[fieldToInt(order.buyToken)] += volume.buyVolume;
+        balances[(fieldToInt(order.account) * TOKENS) + fieldToInt(order.sellToken)] -= volume.sellVolume;
+        balances[(fieldToInt(order.account) * TOKENS) + fieldToInt(order.buyToken)] += volume.buyVolume;
 
         buyVolumes[fieldToInt(order.buyToken)] += volume.buyVolume;
         sellVolumes[fieldToInt(order.sellToken)] += volume.sellVolume;
     }
-
     // check that buyVolume ≈≈ sellVolume for each token, sellVolume cannot be smaller
     for (index=0; index < TOKENS; index++) {
         assert_zero(isNegative(sellVolumes[index] - buyVolumes[index])); 
@@ -74,7 +73,7 @@ void compute(struct In *input, struct Out *output) {
     for (index = 0; index < ACCOUNTS; index++) {
         uint32_t tokenIndex;
         for (tokenIndex = 0; tokenIndex < TOKENS; tokenIndex++) {
-            assert_zero(isNegative(balances[index].token[tokenIndex]));
+            assert_zero(isNegative(balances[(index * TOKENS) + tokenIndex]));
         }
     }
 

--- a/pepper/apps/trade_execution.h
+++ b/pepper/apps/trade_execution.h
@@ -19,7 +19,6 @@ struct In {
     field254 surplus;
     field254 hashBatchInfo[2];
     field254 orderHash;
-    field254 one;
 };
 
 struct Out { field254 state; };

--- a/pepper/test/apps/parsing_test.cpp
+++ b/pepper/test/apps/parsing_test.cpp
@@ -137,28 +137,28 @@ TEST(ParsingTest, ParseBalances) {
     bits[(2*TOKENS*BITS_PER_DECIMAL) + (3*BITS_PER_DECIMAL) - 1] = 1; //acc3
     bits[(3*TOKENS*BITS_PER_DECIMAL) + (4*BITS_PER_DECIMAL) - 1] = 1; //acc4
 
-    struct Balance balances[ACCOUNTS] = { 0 };
+    field254 balances[TOKENS * ACCOUNTS] = { 0 };
     parseBalances(bits, 0, balances);
 
-    ASSERT_EQ(balances[0].token[0], 1);
-    ASSERT_EQ(balances[0].token[1], 0);
-    ASSERT_EQ(balances[0].token[2], 0);
-    ASSERT_EQ(balances[0].token[3], 0);
+    ASSERT_EQ(balances[0], 1);
+    ASSERT_EQ(balances[1], 0);
+    ASSERT_EQ(balances[2], 0);
+    ASSERT_EQ(balances[3], 0);
 
-    ASSERT_EQ(balances[1].token[0], 0);
-    ASSERT_EQ(balances[1].token[1], 1);
-    ASSERT_EQ(balances[1].token[2], 0);
-    ASSERT_EQ(balances[1].token[3], 0);
+    ASSERT_EQ(balances[4], 0);
+    ASSERT_EQ(balances[5], 1);
+    ASSERT_EQ(balances[6], 0);
+    ASSERT_EQ(balances[7], 0);
 
-    ASSERT_EQ(balances[2].token[0], 0);
-    ASSERT_EQ(balances[2].token[1], 0);
-    ASSERT_EQ(balances[2].token[2], 1);
-    ASSERT_EQ(balances[2].token[3], 0);
+    ASSERT_EQ(balances[8], 0);
+    ASSERT_EQ(balances[9], 0);
+    ASSERT_EQ(balances[10], 1);
+    ASSERT_EQ(balances[11], 0);
 
-    ASSERT_EQ(balances[3].token[0], 0);
-    ASSERT_EQ(balances[3].token[1], 0);
-    ASSERT_EQ(balances[3].token[2], 0);
-    ASSERT_EQ(balances[3].token[3], 1);
+    ASSERT_EQ(balances[12], 0);
+    ASSERT_EQ(balances[13], 0);
+    ASSERT_EQ(balances[14], 0);
+    ASSERT_EQ(balances[15], 1);
 }
 
 TEST(ParsingTest, SerializeBalances) {
@@ -168,7 +168,7 @@ TEST(ParsingTest, SerializeBalances) {
     original[(2*TOKENS*BITS_PER_DECIMAL) + (3*BITS_PER_DECIMAL) - 1] = 1;
     original[(3*TOKENS*BITS_PER_DECIMAL) + (4*BITS_PER_DECIMAL) - 1] = 1;
 
-    struct Balance balances[ACCOUNTS] = { 0 };
+    field254 balances[TOKENS*ACCOUNTS] = { 0 };
     parseBalances(original, 0, balances);
 
     // serialize back and expect to match original

--- a/pepper/test/apps/trade_execution_test.cpp
+++ b/pepper/test/apps/trade_execution_test.cpp
@@ -582,7 +582,7 @@ TEST(TradeExecutionTest, BuyVolumeSlightlyGreateSellVolume) {
 }
 
 TEST(TradeExecutionTest, BuyVolumeSlightlyGreaterSellVolume) {
-    struct Balance balances[ACCOUNTS] = {0};
+    field254 balances[TOKENS * ACCOUNTS] = {0};
     struct Order orders[ORDERS] = {0};
     struct Volume volumes[ORDERS] = {0};
     field254 prices[TOKENS] = {1, 1, 1, 1};
@@ -610,8 +610,8 @@ TEST(TradeExecutionTest, BuyVolumeSlightlyGreaterSellVolume) {
     volumes[1].surplus = 1;
 
     //Make sure there is balance
-    balances[0].token[1] = orders[0].sellAmount;
-    balances[1].token[2] = orders[1].sellAmount;
+    balances[1] = orders[0].sellAmount;
+    balances[TOKENS + 2] = orders[1].sellAmount;
 
     //Provide private input
     privateInput = serializePrivateInput(balances, orders, volumes, prices);

--- a/pepper/test/apps/trade_execution_test.cpp
+++ b/pepper/test/apps/trade_execution_test.cpp
@@ -9,7 +9,7 @@
 #include <apps/trade_execution.c>
 #include "util.h"
 
-struct Private serializePrivateInput(struct Balance balances[ACCOUNTS], struct Order orders[ORDERS], struct Volume volumes[ORDERS], field254 prices[TOKENS]) {
+struct Private serializePrivateInput(field254 balances[TOKENS * ACCOUNTS], struct Order orders[ORDERS], struct Volume volumes[ORDERS], field254 prices[TOKENS]) {
     Private result = {};
     serializeOrders(orders, result.orders, 0);
     serializePricesAndVolumes(prices, volumes, result.pricesAndVolumes, 0);
@@ -20,7 +20,7 @@ struct Private serializePrivateInput(struct Balance balances[ACCOUNTS], struct O
 #pragma mark - Valid instances
 
 TEST(TradeExecutionTest, ValidEmptyBatch) {
-    struct Balance balances[ACCOUNTS] = {0};
+    field254 balances[TOKENS * ACCOUNTS] = {0};
     struct Order orders[ORDERS] = {0};
     struct Volume volumes[ORDERS] = {0};
     field254 prices[TOKENS] = {0};
@@ -41,7 +41,7 @@ TEST(TradeExecutionTest, ValidEmptyBatch) {
 }
 
 TEST(TradeExecutionTest, ValidSingleOrderTrade) {
-    struct Balance balances[ACCOUNTS] = {0};
+    field254 balances[TOKENS * ACCOUNTS] = {0};
     struct Order orders[ORDERS] = {0};
     struct Volume volumes[ORDERS] = {0};
     field254 prices[TOKENS] = {1, 1, 1, 1};
@@ -69,8 +69,8 @@ TEST(TradeExecutionTest, ValidSingleOrderTrade) {
     volumes[1].surplus = 1;
 
     //Make sure there is balance
-    balances[0].token[1] = orders[0].sellAmount;
-    balances[1].token[2] = orders[1].sellAmount;
+    balances[1] = orders[0].sellAmount;
+    balances[TOKENS + 2] = orders[1].sellAmount;
 
     //Provide private input
     privateInput = serializePrivateInput(balances, orders, volumes, prices);
@@ -86,17 +86,17 @@ TEST(TradeExecutionTest, ValidSingleOrderTrade) {
     compute(&input, &output);
 
     // Execute trade and check that output matches
-    balances[0].token[1] = 0;
-    balances[0].token[2] = 100;
-    balances[1].token[1] = 100;
-    balances[1].token[2] = 0;
+    balances[1] = 0;
+    balances[2] = 100;
+    balances[TOKENS + 1] = 100;
+    balances[TOKENS + 2] = 0;
     field254* updatedBalances = serializePrivateInput(balances, orders, volumes, prices).balances;
     field254 updatedHash = hashPedersen(updatedBalances, 0, ACCOUNTS*TOKENS*BITS_PER_DECIMAL, BITS_PER_DECIMAL);
     ASSERT_EQ(output.state, updatedHash);
 }
 
 TEST(TradeExecutionTest, ValidSingleOrderRoundedTrade) {
-    struct Balance balances[ACCOUNTS] = {0};
+    field254 balances[TOKENS * ACCOUNTS] = {0};
     struct Order orders[ORDERS] = {0};
     struct Volume volumes[ORDERS] = {0};
     field254 prices[TOKENS] = {1, 1, 1, 1};
@@ -126,8 +126,8 @@ TEST(TradeExecutionTest, ValidSingleOrderRoundedTrade) {
     volumes[1].surplus = 0;
 
     //Make sure there is balance
-    balances[0].token[1] = volumes[0].sellVolume;
-    balances[1].token[2] = volumes[1].sellVolume;
+    balances[1] = volumes[0].sellVolume;
+    balances[TOKENS + 2] = volumes[1].sellVolume;
 
     //Provide private input
     privateInput = serializePrivateInput(balances, orders, volumes, prices);
@@ -143,10 +143,10 @@ TEST(TradeExecutionTest, ValidSingleOrderRoundedTrade) {
     compute(&input, &output);
 
     // Execute trade and check that output matches
-    balances[0].token[1] = 0;
-    balances[0].token[2] = 99;
-    balances[1].token[1] = 100;
-    balances[1].token[2] = 0;
+    balances[1] = 0;
+    balances[2] = 99;
+    balances[TOKENS + 1] = 100;
+    balances[TOKENS + 2] = 0;
     field254* updatedBalances = serializePrivateInput(balances, orders, volumes, prices).balances;
     field254 updatedHash = hashPedersen(updatedBalances, 0, ACCOUNTS*TOKENS*BITS_PER_DECIMAL, BITS_PER_DECIMAL);
     ASSERT_EQ(output.state, updatedHash);
@@ -155,7 +155,7 @@ TEST(TradeExecutionTest, ValidSingleOrderRoundedTrade) {
 #pragma mark - Invalid instances
 
 TEST(TradeExecutionTest, InvalidBalanceHash) {
-    struct Balance balances[ACCOUNTS] = {0};
+    field254 balances[TOKENS * ACCOUNTS] = {0};
     struct Order orders[ORDERS] = {0};
     struct Volume volumes[ORDERS] = {0};
     field254 prices[TOKENS] = {0};
@@ -177,7 +177,7 @@ TEST(TradeExecutionTest, InvalidBalanceHash) {
 }
 
 TEST(TradeExecutionTest, InvalidOrderHash) {
-    struct Balance balances[ACCOUNTS] = {0};
+    field254 balances[TOKENS * ACCOUNTS] = {0};
     struct Order orders[ORDERS] = {0};
     struct Volume volumes[ORDERS] = {0};
     field254 prices[TOKENS] = {0};
@@ -200,7 +200,7 @@ TEST(TradeExecutionTest, InvalidOrderHash) {
 }
 
 TEST(TradeExecutionTest, InvalidBatchInfoHash) {
-    struct Balance balances[ACCOUNTS] = {0};
+    field254 balances[TOKENS * ACCOUNTS] = {0};
     struct Order orders[ORDERS] = {0};
     struct Volume volumes[ORDERS] = {0};
     field254 prices[TOKENS] = {0};
@@ -223,7 +223,7 @@ TEST(TradeExecutionTest, InvalidBatchInfoHash) {
 }
 
 TEST(TradeExecutionTest, InvalidTotalSurplus) {
-    struct Balance balances[ACCOUNTS] = {0};
+    field254 balances[TOKENS * ACCOUNTS] = {0};
     struct Order orders[ORDERS] = {0};
     struct Volume volumes[ORDERS] = {0};
     field254 prices[TOKENS] = {0};
@@ -246,7 +246,7 @@ TEST(TradeExecutionTest, InvalidTotalSurplus) {
 }
 
 TEST(TradeExecutionTest, InvalidVolumeSurplus) {
-    struct Balance balances[ACCOUNTS] = {0};
+    field254 balances[TOKENS * ACCOUNTS] = {0};
     struct Order orders[ORDERS] = {0};
     struct Volume volumes[ORDERS] = {0};
     field254 prices[TOKENS] = {1, 1, 1, 1};
@@ -274,8 +274,8 @@ TEST(TradeExecutionTest, InvalidVolumeSurplus) {
     volumes[1].surplus = 100;
 
     //Make sure there is balance
-    balances[0].token[1] = orders[0].sellAmount;
-    balances[1].token[2] = orders[1].sellAmount;
+    balances[1] = orders[0].sellAmount;
+    balances[TOKENS + 2] = orders[1].sellAmount;
 
     //Provide private input
     privateInput = serializePrivateInput(balances, orders, volumes, prices);
@@ -294,7 +294,7 @@ TEST(TradeExecutionTest, InvalidVolumeSurplus) {
 }
 
 TEST(TradeExecutionTest, NotEnoughBalance) {
-    struct Balance balances[ACCOUNTS] = {0};
+    field254 balances[TOKENS * ACCOUNTS] = {0};
     struct Order orders[ORDERS] = {0};
     struct Volume volumes[ORDERS] = {0};
     field254 prices[TOKENS] = {1, 1, 1, 1};
@@ -322,8 +322,8 @@ TEST(TradeExecutionTest, NotEnoughBalance) {
     volumes[1].surplus = 1;
 
     //Not enough balance
-    balances[0].token[1] = orders[0].sellAmount - 1;
-    balances[1].token[2] = orders[1].sellAmount;
+    balances[1] = orders[0].sellAmount - 1;
+    balances[TOKENS + 2] = orders[1].sellAmount;
 
     //Provide private input
     privateInput = serializePrivateInput(balances, orders, volumes, prices);
@@ -342,7 +342,7 @@ TEST(TradeExecutionTest, NotEnoughBalance) {
 }
 
 TEST(TradeExecutionTest, LimitPriceIgnored) {
-    struct Balance balances[ACCOUNTS] = {0};
+    field254 balances[TOKENS * ACCOUNTS] = {0};
     struct Order orders[ORDERS] = {0};
     struct Volume volumes[ORDERS] = {0};
     field254 prices[TOKENS] = {1, 1, 1, 1};
@@ -370,8 +370,8 @@ TEST(TradeExecutionTest, LimitPriceIgnored) {
     volumes[1].surplus = 1;
 
     //Make sure there is balance
-    balances[0].token[1] = orders[0].sellAmount;
-    balances[1].token[2] = orders[1].sellAmount;
+    balances[1] = orders[0].sellAmount;
+    balances[TOKENS + 2] = orders[1].sellAmount;
 
     //Provide private input
     privateInput = serializePrivateInput(balances, orders, volumes, prices);
@@ -390,7 +390,7 @@ TEST(TradeExecutionTest, LimitPriceIgnored) {
 }
 
 TEST(TradeExecutionTest, TotalBoughtAndSoldDontMatch) {
-    struct Balance balances[ACCOUNTS] = {0};
+    field254 balances[TOKENS * ACCOUNTS] = {0};
     struct Order orders[ORDERS] = {0};
     struct Volume volumes[ORDERS] = {0};
     field254 prices[TOKENS] = {100, 100, 100, 100};
@@ -418,8 +418,8 @@ TEST(TradeExecutionTest, TotalBoughtAndSoldDontMatch) {
     volumes[1].surplus = 100;
 
     //Make sure there is balance
-    balances[0].token[1] = orders[0].sellAmount;
-    balances[1].token[2] = orders[1].sellAmount;
+    balances[1] = orders[0].sellAmount;
+    balances[TOKENS + 2] = orders[1].sellAmount;
 
     //Provide private input
     privateInput = serializePrivateInput(balances, orders, volumes, prices);
@@ -438,7 +438,7 @@ TEST(TradeExecutionTest, TotalBoughtAndSoldDontMatch) {
 }
 
 TEST(TradeExecutionTest, MoreVolumeThanAuthorized) {
-    struct Balance balances[ACCOUNTS] = {0};
+    field254 balances[TOKENS * ACCOUNTS] = {0};
     struct Order orders[ORDERS] = {0};
     struct Volume volumes[ORDERS] = {0};
     field254 prices[TOKENS] = {1, 1, 1, 1};
@@ -466,8 +466,8 @@ TEST(TradeExecutionTest, MoreVolumeThanAuthorized) {
     volumes[1].surplus = 1;
 
     //Make sure there is balance
-    balances[0].token[1] = volumes[0].sellVolume;
-    balances[1].token[2] = volumes[1].sellVolume;
+    balances[1] = volumes[0].sellVolume;
+    balances[TOKENS + 2] = volumes[1].sellVolume;
 
     //Provide private input
     privateInput = serializePrivateInput(balances, orders, volumes, prices);
@@ -486,10 +486,10 @@ TEST(TradeExecutionTest, MoreVolumeThanAuthorized) {
 }
 
 TEST(TradeExecutionTest, PriceDoesntMatchVolume) {
-    struct Balance balances[ACCOUNTS] = {0};
+    field254 balances[TOKENS * ACCOUNTS] = {0};
     struct Order orders[ORDERS] = {0};
     struct Volume volumes[ORDERS] = {0};
-    field254 prices[TOKENS] = {10, 5, 10, 10};
+    field254 prices[TOKENS] = {1000, 1, 1000, 1000};
 
     // First order
     orders[0].account = 0;
@@ -508,14 +508,14 @@ TEST(TradeExecutionTest, PriceDoesntMatchVolume) {
     // More volume than authorized
     volumes[0].sellVolume = 100;
     volumes[0].buyVolume = 100;
-    volumes[0].surplus = 10;
+    volumes[0].surplus = 1000;
     volumes[1].sellVolume = 100;
     volumes[1].buyVolume = 100;
-    volumes[1].surplus = 5;
+    volumes[1].surplus = 1;
 
     //Make sure there is balance
-    balances[0].token[1] = volumes[0].sellVolume;
-    balances[1].token[2] = volumes[1].sellVolume;
+    balances[1] = volumes[0].sellVolume;
+    balances[TOKENS + 2] = volumes[1].sellVolume;
 
     //Provide private input
     privateInput = serializePrivateInput(balances, orders, volumes, prices);
@@ -523,7 +523,7 @@ TEST(TradeExecutionTest, PriceDoesntMatchVolume) {
     ShaResult hashBatchInfo = hashSHA(privateInput.pricesAndVolumes, 0, (TOKENS*BITS_PER_DECIMAL)+(ORDERS*BITS_PER_DECIMAL), 256);
     struct In input {
         hashPedersen(privateInput.balances, 0, ACCOUNTS*TOKENS*BITS_PER_DECIMAL, BITS_PER_DECIMAL), // state
-        15, //surplus
+        1001, //surplus
         {hashBatchInfo.left, hashBatchInfo.right}, //hashBatchInfo
         hashPedersen(privateInput.orders, 0, ORDERS*BITS_PER_ORDER, BITS_PER_ORDER)
     };
@@ -534,7 +534,7 @@ TEST(TradeExecutionTest, PriceDoesntMatchVolume) {
 }
 
 TEST(TradeExecutionTest, BuyVolumeSlightlyGreateSellVolume) {
-    struct Balance balances[ACCOUNTS] = {0};
+    field254 balances[TOKENS * ACCOUNTS] = {0};
     struct Order orders[ORDERS] = {0};
     struct Volume volumes[ORDERS] = {0};
     field254 prices[TOKENS] = {1, 1, 1, 1};
@@ -562,8 +562,8 @@ TEST(TradeExecutionTest, BuyVolumeSlightlyGreateSellVolume) {
     volumes[1].surplus = 1;
 
     //Make sure there is balance
-    balances[0].token[1] = orders[0].sellAmount;
-    balances[1].token[2] = orders[1].sellAmount;
+    balances[1] = orders[0].sellAmount;
+    balances[TOKENS + 2] = orders[1].sellAmount;
 
     //Provide private input
     privateInput = serializePrivateInput(balances, orders, volumes, prices);


### PR DESCRIPTION
When running the main snark with real data (output from the solver), I noticed that the balances were not updated correctly.

This is most likely due to pepper not handling structs with arrays well. Balances were modelled as an array of 
```C
struct Balance {
  field254 tokens[TOKEN]
}
```

where each struct itself contained a subarray of token balances for this account.

This diff changes balances to being a single array of field elements, with account `i`'s token balance for `t` being stored at index `i*TOKENS + t`.

I updated the unit tests and verified that state transitions are applied correctly when running the main snark with real data inside pepper (adding that functionality will come in a separate PR).