### PR TITLE
Handle negative values correctly in decompose

### DIFF
--- a/pepper/exo_compute/decompose_bits.py
+++ b/pepper/exo_compute/decompose_bits.py
@@ -13,9 +13,7 @@ fraction = line.split()[1] # format "numerator%denominator"
 
 # Assuming denominator is always 1
 number = int(fraction.split('%')[0])
-if number < 0:
-    number += 21888242871839275222246405745257275088548364400416034343698204186575808495617
-assert(number < 2**254)
+number %= 21888242871839275222246405745257275088548364400416034343698204186575808495617
 
 # Output for pepper
 print " " + " ".join([i for i in "{:0254b}".format(number)])

--- a/pepper/exo_compute/decompose_bits.py
+++ b/pepper/exo_compute/decompose_bits.py
@@ -13,6 +13,8 @@ fraction = line.split()[1] # format "numerator%denominator"
 
 # Assuming denominator is always 1
 number = int(fraction.split('%')[0])
+if number < 0:
+    number += 21888242871839275222246405745257275088548364400416034343698204186575808495617
 assert(number < 2**254)
 
 # Output for pepper


### PR DESCRIPTION
Simple fix that makes sure we always take the positive representation (mod p) of the field element we are trying to decompose.