### PR TITLE
Real implementation of hash gadgets in tests

### DIFF
--- a/pepper/Makefile
+++ b/pepper/Makefile
@@ -9,7 +9,7 @@ IFLAGS = -Iext_gadget -I$(LIBSNARK)/ -I$(LIBSNARK)/depends/libff -I$(LIBSNARK)/d
 LDFLAGS = -L$(LIBSNARK)/build/libsnark -L$(LIBSNARK)/build/depends/libff/libff
 LDFLAGS += -lsnark -lff -lgmp -lgmpxx
 
-TEST_LDFLAGS = -lgtest -lpthread -lboost_stacktrace_backtrace -DBOOST_STACKTRACE_USE_BACKTRACE -ldl
+TEST_LDFLAGS = -lgtest -lpthread -lboost_stacktrace_backtrace -DBOOST_STACKTRACE_USE_BACKTRACE -ldl -lssl -lcrypto
 TEST_IFLAGS = -I./
 TEST_BIN = test/bin/
 
@@ -25,6 +25,7 @@ make-bin: check-env
 	mkdir -p $(PEPPER)/pepper/prover_verifier_shared
 	mkdir -p $(TEST_BIN)
 	mkdir -p scripts/bin
+	mkdir -p exo_compute/bin
 
 # Convenience target to compile gadgets 0..n
 gadgets: gadget0 gadget1
@@ -53,11 +54,11 @@ e2e-tests: check-env
 unit-tests: $(patsubst test/apps/%.cpp, app_%, $(wildcard test/apps/*_test.cpp))
 
 app_%_test: test/apps/%_test.cpp
-	$(CXX) -g $(CXXFLAGS) -DTEST $(TEST_IFLAGS) $(IFLAGS) $< -o $(TEST_BIN)/$@ $(TEST_LDFLAGS) $(LDFLAGS) 
+	$(CXX) -g $(CXXFLAGS) -DBIGINT $(TEST_IFLAGS) $(ETHSNARK_IFLAGS) $(IFLAGS) $< -o $(TEST_BIN)/$@ $(ETHSNARK_SRC) $(TEST_LDFLAGS) $(LDFLAGS) 
 	$(TEST_BIN)/$@
 
 gadget-tests: test/gadgets/main.cpp
-	$(CXX) $(CXXFLAGS) $(IFLAGS) -Iext_gadget/ $< ext_gadget/gadgets/*.cpp ext_gadget/gadgets/jubjub/*.cpp -o $(TEST_BIN)/run_gadget_tests $(LDFLAGS) $(TEST_LDFLAGS)
+	$(CXX) $(CXXFLAGS) $(IFLAGS) -Iext_gadget/ $< -o $(TEST_BIN)/run_gadget_tests $(LDFLAGS) $(TEST_LDFLAGS)
 	$(TEST_BIN)/run_gadget_tests
 	
 scripts: scripts/pepper_binary_format_reader.cpp make-bin

--- a/pepper/Makefile
+++ b/pepper/Makefile
@@ -56,10 +56,6 @@ unit-tests: $(patsubst test/apps/%.cpp, app_%, $(wildcard test/apps/*_test.cpp))
 app_%_test: test/apps/%_test.cpp
 	$(CXX) -g $(CXXFLAGS) -DBIGINT $(TEST_IFLAGS) $(ETHSNARK_IFLAGS) $(IFLAGS) $< -o $(TEST_BIN)/$@ $(ETHSNARK_SRC) $(TEST_LDFLAGS) $(LDFLAGS) 
 	$(TEST_BIN)/$@
-
-gadget-tests: test/gadgets/main.cpp
-	$(CXX) $(CXXFLAGS) $(IFLAGS) -Iext_gadget/ $< -o $(TEST_BIN)/run_gadget_tests $(LDFLAGS) $(TEST_LDFLAGS)
-	$(TEST_BIN)/run_gadget_tests
 	
 scripts: scripts/pepper_binary_format_reader.cpp make-bin
 	$(CXX) $(CXXFLAGS) -DBINARY_OUTPUT $(IFLAGS) $< -o scripts/bin/pepper_binary_format_reader $(LDFLAGS)

--- a/pepper/ext_gadget/pedersen_bridge.cpp
+++ b/pepper/ext_gadget/pedersen_bridge.cpp
@@ -22,7 +22,6 @@ uint64_t outputSize() {
 
 ethsnarks::jubjub::PedersenHash makeGadget(const char* assignment, protoboard<FieldT>& pb)
 {
-    ethsnarks::ppT::init_public_params();
     const ethsnarks::jubjub::Params params;
 
     ethsnarks::VariableArrayT in;
@@ -59,6 +58,7 @@ ethsnarks::jubjub::PedersenHash makeGadget(const char* assignment, protoboard<Fi
 }
 
 protoboard<FieldT> getProtoboard(const char* assignment) {
+    ethsnarks::ppT::init_public_params();
     protoboard<FieldT> pb;
     makeGadget(assignment, pb);
     return pb;

--- a/pepper/ext_gadget/pedersen_bridge.cpp
+++ b/pepper/ext_gadget/pedersen_bridge.cpp
@@ -20,11 +20,10 @@ uint64_t outputSize() {
     return OUTPUT_SIZE;
 }
 
-protoboard<FieldT> getProtoboard(const char* assignment)
+ethsnarks::jubjub::PedersenHash makeGadget(const char* assignment, protoboard<FieldT>& pb)
 {
     ethsnarks::ppT::init_public_params();
     const ethsnarks::jubjub::Params params;
-    protoboard<FieldT> pb;
 
     ethsnarks::VariableArrayT in;
     // The gadget expects input that is a multiple of three. Thus, we pad with 0s.
@@ -56,5 +55,11 @@ protoboard<FieldT> getProtoboard(const char* assignment)
         assert(pb.is_satisfied());
     }
     
+    return f;
+}
+
+protoboard<FieldT> getProtoboard(const char* assignment) {
+    protoboard<FieldT> pb;
+    makeGadget(assignment, pb);
     return pb;
 }

--- a/pepper/test/apps/util.h
+++ b/pepper/test/apps/util.h
@@ -1,5 +1,7 @@
 #include <apps/hashing.h>
 #include <boost/stacktrace.hpp>
+#include <openssl/sha.h>
+#include <pedersen_bridge.cpp>
 
 #ifndef ORDERS
 #define ORDERS 1
@@ -7,22 +9,41 @@
 
 namespace pepper_overrides
 {
-    /**
-     * Dummy pedersen implementation: XOR lhs and rhs bits
-     */
-    void sha(field254 in[SHA_HASH_SIZE], field254 out[256]) {
-        for (size_t index = 0; index < 256; index++) {
-            out[index] += in[index].is_zero() ^ in[index+256].is_zero();
+    void charArrayToFieldArray(unsigned char *in, field254 *out, size_t length) {
+        for (size_t index = 0; index < length; index++) {
+            for (size_t bit = 0; bit < 8; bit++) {
+                out[(index*8) + bit] = (in[index] >> (7 - bit)) % 2;
+            }
         }
     }
 
-    /**
-     * Dummy pedersen implementation: Sum of all inputs
-     */
-    void pedersen(field254 in[PEDERSEN_HASH_SIZE], field254 out[2]) {
-        for (size_t index = 0; index < PEDERSEN_HASH_SIZE; index++) {
-            out[0] += in[index];
+    void fieldArrayToCharArray(field254 *in, unsigned char *out, size_t length) {
+        for (size_t index = 0; index < length; index++) {
+            out[index/8] += in[index].is_zero() ? 0 : int(pow(2, 7 - (index % 8)));
         }
+    }
+
+    void sha(field254 in[SHA_HASH_SIZE], field254 out[256]) {
+        unsigned char charIn[SHA_HASH_SIZE/8] = {0};
+        unsigned char charOut[32] = {0};
+        SHA256_CTX sha256;
+        SHA256_Init(&sha256);
+        fieldArrayToCharArray(in, charIn, SHA_HASH_SIZE);
+        SHA256_Update(&sha256, charIn, SHA_HASH_SIZE/8);
+        SHA256_Final(charOut, &sha256);
+        charArrayToFieldArray(charOut, out, 32);
+    }
+
+    void pedersen(field254 in[PEDERSEN_HASH_SIZE], field254 out[2]) {
+        protoboard<FieldT> pb;
+        char charIn[2*PEDERSEN_HASH_SIZE] = {0};
+        for (size_t i = 0; i < PEDERSEN_HASH_SIZE; i++) {
+            charIn[2*i] = in[i].is_zero() ? '0' : '1';
+            charIn[2*i + 1] = ' ';
+        }
+        auto gadget = makeGadget(charIn, pb);
+        out[0] = pb.val(gadget.result_x());
+        out[1] = pb.val(gadget.result_y());
     }
 
     void decomposeBits(field254 number, field254* bits, uint32_t offset) {
@@ -58,14 +79,12 @@ void ext_gadget(void* in, void* out, uint32_t gadget) {
 struct Private privateInput;
 void exo_compute(field254** input, uint32_t* length, void* output, uint32_t exo) {
     switch(exo) {
-        case 0:
-            ((Private*)output)[0] = privateInput;
-            break;
         case 1:
             pepper_overrides::decomposeBits(input[0][0],((Decomposed*) output)->bits, 0);
             break;
         default:
-            FAIL();
+            ((Private*)output)[0] = privateInput;
+            break;
     }
 }
 #endif

--- a/pepper/test/apps/util.h
+++ b/pepper/test/apps/util.h
@@ -47,15 +47,8 @@ namespace pepper_overrides
     }
 
     void decomposeBits(field254 number, field254* bits, uint32_t offset) {
-        int index = 0;
-        unsigned long nr = number.as_ulong();
-        while (nr > 0) {
-            if(nr%2==0)
-                bits[offset + 253 - index] = field254::zero();
-            else
-                bits[offset + 253 - index] = field254::one();
-            nr = nr/2;
-            index++;
+        for (size_t index = 0; index < number.as_bigint().num_bits(); index++) {
+            bits[offset + 253 - index] = number.as_bigint().test_bit(index);
         }
     }
 } // pepper_overrides


### PR DESCRIPTION
We have been using dummy implementations for our hash functions inside the unit tests. While this was fine for unit tests, it is a problem if we want to share the same code to convert the solver's output (json) into public/private input for pepper (which requires passing the correct hashes).

This change makes it so that we use real implementations for the hash function in the test. We could consider making the concrete implementation "depend" on a macro (different for test/input conversion) if we feel that compiling the gadgets for the unit tests becomes too time consuming.