### PR TITLE
Implement is negative using bitwise comparison

### DIFF
--- a/pepper/apps/dex_common.h
+++ b/pepper/apps/dex_common.h
@@ -72,9 +72,27 @@ uint32_t fieldToInt(field254 field) {
 #endif
 }
 
+field254 maxPositiveFieldBits[254] = {0, 1, 1, 0, 0, 0, 0, 0, 1, 1, 0, 0, 1, 0, 0, 0, 1, 0, 0, 1, 1, 1, 0, 0, 1, 1, 1, 0, 0, 1, 0, 1, 1, 1, 0, 0, 0, 0, 1, 0, 0, 1, 1, 0, 0, 0, 1, 1, 0, 1, 0, 0, 0, 0, 0, 0, 0, 1, 0, 1, 0, 0, 1, 1, 0, 1, 1, 1, 0, 0, 0, 0, 1, 0, 1, 0, 0, 0, 0, 0, 1, 0, 0, 0, 1, 0, 1, 1, 0, 1, 1, 0, 1, 1, 0, 1, 0, 0, 0, 0, 0, 0, 1, 1, 0, 0, 0, 0, 0, 0, 1, 0, 1, 0, 1, 1, 0, 0, 0, 0, 1, 0, 1, 1, 1, 0, 1, 0, 0, 1, 0, 1, 0, 0, 0, 0, 0, 1, 1, 0, 0, 1, 1, 1, 1, 1, 0, 1, 0, 0, 0, 0, 1, 0, 0, 1, 0, 0, 0, 0, 1, 1, 1, 1, 0, 0, 1, 1, 0, 1, 1, 1, 0, 0, 1, 0, 1, 1, 1, 0, 0, 0, 0, 1, 0, 0, 1, 0, 0, 0, 1, 0, 1, 0, 0, 0, 0, 1, 1, 1, 1, 1, 0, 0, 0, 0, 1, 1, 1, 1, 1, 0, 1, 0, 1, 1, 0, 0, 1, 0, 0, 1, 1, 1, 1, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
 bool isNegative(field254 field) {
 #ifndef BIGINT
-    return field < 0; //TODO verify this work in pepper
+    field254 fieldBits[254] = {0};
+    decomposeBits(field, fieldBits, 0, 254);
+    uint32_t index;
+    bool result, found = 0;
+    for(index = 0; index < 254; index++) {
+        if (found == 1) {
+            // we have found the different bit
+        } else if(maxPositiveFieldBits[index] - fieldBits[index] == 1) {
+            // maxPositiveField > field -> not negative
+            found = 1;
+        } else if (maxPositiveFieldBits[index] - fieldBits[index] != 0) {
+            // maxPositiveField < field -> negative
+            result = 1;
+            found = 1;
+        }
+    }
+    //maxPositiveField == field -> not negative
+    return result;
 #else
     mpz_t max_signed, r;
     mpz_init(r); mpz_init_set_str(max_signed, "10944121435919637611123202872628637544274182200208017171849102093287904247808", 10);

--- a/pepper/apps/trade_execution.c
+++ b/pepper/apps/trade_execution.c
@@ -44,8 +44,10 @@ void compute(struct In *input, struct Out *output) {
         field254 lhs = volume.buyVolume * prices[fieldToInt(order.buyToken)];
         field254 rhs = volume.sellVolume * prices[fieldToInt(order.sellToken)];
         field254 delta = lhs - rhs;
+
         // Make sure |delta| < epsilon
-        assert_zero(isNegative((input->epsilon*input->epsilon) - delta) || isNegative((input->epsilon*input->epsilon) + delta));
+        assert_zero(isNegative((input->epsilon*input->epsilon) - delta));
+        assert_zero(isNegative((input->epsilon*input->epsilon) + delta));
 
         // Limit price compliance
         assert_zero(isNegative(fieldToInt(volume.sellVolume * order.buyAmount) - fieldToInt(volume.buyVolume * order.sellAmount)));


### PR DESCRIPTION
https://travis-ci.org/gnosis/dex-zksnarks/builds/473875064 shows a lot of warnings about `Coefficient larger than prime` and `change references on a polynomial`. It turns out that these warnings are coming from the isNegative is implemented inside pepper.

Long term, we probably want to create a gadget for it (#36), but for the short term we can implement a bit wise comparison with p-1/2 in pepper.