### PR TITLE
Considering balances in price finder output conversion

### DIFF
--- a/pepper/apps/trade_execution.c
+++ b/pepper/apps/trade_execution.c
@@ -58,8 +58,9 @@ void compute(struct In *input, struct Out *output) {
         assert_zero(isNegative((((volume.buyVolume * order.sellAmount) - (volume.sellVolume * order.buyAmount)) * prices[fieldToInt(order.buyToken)]) - (volume.surplus * order.sellAmount)));
         totalSurplus += volume.surplus;
         
-        balances[(fieldToInt(order.account) * TOKENS) + fieldToInt(order.sellToken)] -= volume.sellVolume;
-        balances[(fieldToInt(order.account) * TOKENS) + fieldToInt(order.buyToken)] += volume.buyVolume;
+        uint32_t accountOffset = fieldToInt(order.account) * TOKENS;
+        balances[accountOffset + fieldToInt(order.sellToken)] -= volume.sellVolume;
+        balances[accountOffset + fieldToInt(order.buyToken)] += volume.buyVolume;
 
         buyVolumes[fieldToInt(order.buyToken)] += volume.buyVolume;
         sellVolumes[fieldToInt(order.sellToken)] += volume.sellVolume;

--- a/pepper/exo_compute/price_finder_output_conversion.cpp
+++ b/pepper/exo_compute/price_finder_output_conversion.cpp
@@ -42,12 +42,27 @@ int main(int argc, char **argv) {
         const auto& tokenId = tokenAndPrice.key().asString();
         tokenIndexMapping[tokenId] = tokenIndex;
         prices[tokenIndex] = field254(priceMapping[tokenId.c_str()].asCString());
-
-        // set enough balance for account 1
-        balances[tokenIndex] = field254("100000000000000000000000");
-        
         tokenIndex++;
     }
+
+    auto accounts = obj["accounts"];
+    map<string, size_t> accountIndexMapping;
+    size_t accountIndex = 0;
+    for (auto accountAndBalances = accounts.begin(); accountAndBalances != accounts.end(); accountAndBalances++) {
+        const auto& accountId = accountAndBalances.key().asString();
+        accountIndexMapping[accountId] = accountIndex;
+        auto& tokens = accounts[accountId.c_str()];
+        for (auto tokenAndBalance = tokens.begin(); tokenAndBalance != tokens.end(); tokenAndBalance++) {
+            const auto& tokenId = tokenAndBalance.key().asString();
+            auto index = (accountIndex * TOKENS) + tokenIndexMapping[tokenId];
+            balances[index] = field254(tokens[tokenId.c_str()].asCString());
+        }
+        accountIndex++;
+    }
+
+    const size_t serializedLength = ORDERS*BITS_PER_ORDER + (TOKENS*BITS_PER_DECIMAL)+(4*ORDERS*BITS_PER_DECIMAL) + ACCOUNTS*TOKENS*BITS_PER_DECIMAL;
+    field254* serialized = (field254*)malloc(serializedLength * sizeof(field254));
+    serializeBalances(balances, serialized, serializedLength - (ACCOUNTS*TOKENS*BITS_PER_DECIMAL));
 
     // Parse orders & Volumes
     auto orderList = obj["orders"];
@@ -58,23 +73,24 @@ int main(int argc, char **argv) {
         orders[orderIndex].buyToken = field254(tokenIndexMapping[order["buyToken"].asString()]);
         orders[orderIndex].sellAmount = field254(order["sellAmount"].asCString());
         orders[orderIndex].buyAmount = field254(order["buyAmount"].asCString());
-        orders[orderIndex].account = 0;
+        orders[orderIndex].account = field254(accountIndexMapping[order["accountID"].asString()]);
         
         volumes[orderIndex].sellVolume = field254(order["execSellAmount"].asCString());
         volumes[orderIndex].buyVolume = field254(order["execBuyAmount"].asCString());
         volumes[orderIndex].surplus = field254(order["execSurplus"].asCString());
 
+        //adjust balance
+        auto sellIndex = (orders[orderIndex].account.as_ulong() * TOKENS) + orders[orderIndex].sellToken.as_ulong();
+        auto buyIndex = (orders[orderIndex].account.as_ulong() * TOKENS) + orders[orderIndex].buyToken.as_ulong();
+        balances[sellIndex] -= volumes[orderIndex].sellVolume;
+        balances[buyIndex] += volumes[orderIndex].buyVolume;
+
         totalSurplus += volumes[orderIndex].surplus;
         orderIndex++;
     }
 
-    //TODO balances
-
-    const size_t serializedLength = ORDERS*BITS_PER_ORDER + (TOKENS*BITS_PER_DECIMAL)+(4*ORDERS*BITS_PER_DECIMAL) + ACCOUNTS*TOKENS*BITS_PER_DECIMAL;
-    field254* serialized = (field254*)malloc(serializedLength * sizeof(field254));
     serializeOrders(orders, serialized, 0);
     serializePricesAndVolumes(prices, volumes, serialized, ORDERS*BITS_PER_ORDER);
-    serializeBalances(balances, serialized, serializedLength - (ACCOUNTS*TOKENS*BITS_PER_DECIMAL));
 
     ofstream privateInputFile(argv[3]);
     privateInputFile << "#!/bin/bash" << endl << "echo \"";
@@ -97,6 +113,12 @@ int main(int argc, char **argv) {
     publicInputFile << fieldToString(orderHash) << endl;
     publicInputFile << "10000000000000"; //epsilon
     publicInputFile.close();
+
+    // Print expected output
+    cout << "0" <<endl;
+    field254* updatedSerializedBalances = (field254*)malloc(ACCOUNTS*TOKENS*BITS_PER_DECIMAL * sizeof(field254));
+    serializeBalances(balances, updatedSerializedBalances, 0);
+    hashPedersen(updatedSerializedBalances, 0, ACCOUNTS*TOKENS*BITS_PER_DECIMAL, BITS_PER_DECIMAL).print();
 
     return 0;
 }

--- a/pepper/test/e2e/larger_trade_execution.json
+++ b/pepper/test/e2e/larger_trade_execution.json
@@ -1,0 +1,141 @@
+{
+    "tokens": [
+        "T01", 
+        "T02", 
+        "T03"
+    ], 
+    "prices": {
+        "T03": "59907336690483042219", 
+        "T02": "3349294175609897728", 
+        "T01": "13550460422233049584"
+    }, 
+    "accounts": {
+        "0x01": {
+            "T03": "62792536129545912", 
+            "T02": "3819504765437463040", 
+            "T01": "4120861682700793792"
+        }, 
+        "0x02": {
+            "T03": "574112925215378176", 
+            "T02": "3549186443520937984", 
+            "T01": "1459207827349194752"
+        }, 
+        "0x03": {
+            "T03": "39497251070580136", 
+            "T02": "0", 
+            "T01": "0"
+        }
+    }, 
+    "orders": [
+        {
+            "ID": "001", 
+            "accountID": "0x02", 
+            "sellToken": "T01", 
+            "sellAmount": "1459207827349194752", 
+            "buyToken": "T02", 
+            "buyAmount": "7087133857849015296", 
+            "execSellAmount": "0", 
+            "execBuyAmount": "0", 
+            "execSurplus": "0"
+        }, 
+        {
+            "ID": "002", 
+            "accountID": "0x01", 
+            "sellToken": "T01", 
+            "sellAmount": "414341383330227392", 
+            "buyToken": "T02", 
+            "buyAmount": "1912515242603871488", 
+            "execSellAmount": "0", 
+            "execBuyAmount": "0", 
+            "execSurplus": "0"
+        }, 
+        {
+            "ID": "003", 
+            "accountID": "0x02", 
+            "sellToken": "T02", 
+            "sellAmount": "3549186443520937984", 
+            "buyToken": "T01", 
+            "buyAmount": "847590166327780864", 
+            "execSellAmount": "3549186443520937984", 
+            "execBuyAmount": "877259451932285041", 
+            "execSurplus": "402032480339762610039889580976112368"
+        }, 
+        {
+            "ID": "004", 
+            "accountID": "0x01", 
+            "sellToken": "T02", 
+            "sellAmount": "3819504765437463040", 
+            "buyToken": "T01", 
+            "buyAmount": "1025549089710961408", 
+            "execSellAmount": "0", 
+            "execBuyAmount": "0", 
+            "execSurplus": "0"
+        }, 
+        {
+            "ID": "005", 
+            "accountID": "0x01", 
+            "sellToken": "T01", 
+            "sellAmount": "3035906927774456320", 
+            "buyToken": "T03", 
+            "buyAmount": "599679224203245056", 
+            "execSellAmount": "877259451932285127", 
+            "execBuyAmount": "198427607370612966", 
+            "execSurplus": "1506283168418889572677738427251584829"
+        }, 
+        {
+            "ID": "006", 
+            "accountID": "0x01", 
+            "sellToken": "T01", 
+            "sellAmount": "670613371596110080", 
+            "buyToken": "T03", 
+            "buyAmount": "172241858029632896", 
+            "execSellAmount": "0", 
+            "execBuyAmount": "0", 
+            "execSurplus": "0"
+        }, 
+        {
+            "ID": "007", 
+            "accountID": "0x01", 
+            "sellToken": "T03", 
+            "sellAmount": "62792536129545912", 
+            "buyToken": "T02", 
+            "buyAmount": "1123142192452242816", 
+            "execSellAmount": "45271378308031530", 
+            "execBuyAmount": "809749027867225557", 
+            "execSurplus": "47721191055313823791"
+        }, 
+        {
+            "ID": "008", 
+            "accountID": "0x02", 
+            "sellToken": "T03", 
+            "sellAmount": "113658977992001408", 
+            "buyToken": "T02", 
+            "buyAmount": "1727057110762735104", 
+            "execSellAmount": "113658977992001403", 
+            "execBuyAmount": "2032967636001435276", 
+            "execSurplus": "1024584340439743359429410226437963764"
+        }, 
+        {
+            "ID": "009", 
+            "accountID": "0x03", 
+            "sellToken": "T03", 
+            "sellAmount": "39497251070580136", 
+            "buyToken": "T02", 
+            "buyAmount": "648870978267938304", 
+            "execSellAmount": "39497251070580033", 
+            "execBuyAmount": "706469779652277071", 
+            "execSurplus": "192915329998682814015244170220494017"
+        }, 
+        {
+            "ID": "010", 
+            "accountID": "0x02", 
+            "sellToken": "T03", 
+            "sellAmount": "460453947223376768", 
+            "buyToken": "T02", 
+            "buyAmount": "10530879648310986752", 
+            "execSellAmount": "0", 
+            "execBuyAmount": "0", 
+            "execSurplus": "0"
+        }
+    ]
+}

--- a/pepper/test/e2e/trade_execution.json
+++ b/pepper/test/e2e/trade_execution.json
@@ -8,9 +8,17 @@
         "T01": "1000", 
         "T02": "2000", 
         "T03": "10000"
-    }, 
+    },
+    "accounts": {
+        "0x01": {
+            "T03": "10000", 
+            "T02": "10000", 
+            "T01": "10000"
+        }
+    },
     "orders": [
         {
+            "accountID": "0x01",
             "execSellAmount": "1000", 
             "sellAmount": "1000", 
             "execBuyAmount": "2000", 
@@ -21,6 +29,7 @@
             "buyToken": "T02"
         }, 
         {
+            "accountID": "0x01",
             "execSellAmount": "2000", 
             "sellAmount": "2000", 
             "execBuyAmount": "10000", 
@@ -31,6 +40,7 @@
             "buyToken": "T03"
         }, 
         {
+            "accountID": "0x01",
             "execSellAmount": "10000", 
             "sellAmount": "20000", 
             "execBuyAmount": "1000", 

--- a/pepper/test/e2e/trade_execution.sh
+++ b/pepper/test/e2e/trade_execution.sh
@@ -2,16 +2,27 @@
 set -e
 source ./test/e2e/common.sh
 
+function runTradeExecution() {
+    make price_finder_output_conversion
+    make link-apps
+
+    echo "Converting json to private/public input:"
+    ./exo_compute/bin/price_finder_output_conversion $1 $PEPPER/pepper/prover_verifier_shared/trade_execution.inputs $PEPPER/pepper/bin/exo2 > ./test/e2e/trade_execution.expected_output
+    chmod +x $PEPPER/pepper/bin/exo2
+
+    runApp trade_execution
+
+    diff $PEPPER/pepper/prover_verifier_shared/trade_execution.outputs ./test/e2e/trade_execution.expected_output
+}
+
+# Small example
 sed -i 's/#define ORDERS [0-9]*/#define ORDERS 3/g' apps/trade_execution.h
 sed -i 's/#define TOKENS [0-9]*/#define TOKENS 3/g' apps/trade_execution.h
 sed -i 's/#define ACCOUNTS [0-9]*/#define ACCOUNTS 1/g' apps/trade_execution.h
-make price_finder_output_conversion
-make link-apps
+runTradeExecution ./test/e2e/trade_execution.json
 
-echo "Converting json to private/public input:"
-./exo_compute/bin/price_finder_output_conversion ./test/e2e/trade_execution.json $PEPPER/pepper/prover_verifier_shared/trade_execution.inputs $PEPPER/pepper/bin/exo2
-chmod +x $PEPPER/pepper/bin/exo2
-
-runApp trade_execution
-
-diff $PEPPER/pepper/prover_verifier_shared/trade_execution.outputs <(printf "0\n6490902738647173036319167296619824463594166904014951787745877661502068588144\n")
+# Larger example
+sed -i 's/#define ORDERS [0-9]*/#define ORDERS 10/g' apps/trade_execution.h
+sed -i 's/#define TOKENS [0-9]*/#define TOKENS 3/g' apps/trade_execution.h
+sed -i 's/#define ACCOUNTS [0-9]*/#define ACCOUNTS 3/g' apps/trade_execution.h
+runTradeExecution ./test/e2e/larger_trade_execution.json


### PR DESCRIPTION
@tomtiger87 has included balances into the output json, so that we can now create complete private input for our main execution snark.

Also, the rounding is now working with a real world example, so I'm adding an e2e test that comes directly from one of the outputs.