### PR TITLE
Parellelized reading of the R1CS

### DIFF
--- a/bellman/Cargo.toml
+++ b/bellman/Cargo.toml
@@ -8,3 +8,5 @@ bellman = { git = 'https://github.com/matterinc/bellman' }
 rand = "0.4"
 pairing = { git = 'https://github.com/matterinc/pairing' }
 ff = { version = "0.4", features = ["derive"] }
+rayon = "1.0"
+multimap = "0.4.0"

--- a/bellman/src/main.rs
+++ b/bellman/src/main.rs
@@ -1,78 +1,26 @@
-#![allow(unused_imports)]
-#![allow(unused_variables)]
 extern crate bellman;
 extern crate pairing;
 extern crate rand;
 extern crate ff;
+extern crate rayon;
+extern crate multimap;
+use multimap::MultiMap;
+use rayon::prelude::*;
 use bellman::{Circuit, ConstraintSystem, SynthesisError, Variable, LinearCombination};
 use pairing::{Engine};
 use std::fs::File;
 use std::io::{BufReader, BufRead};
 use std::time::{Instant};
+use std::sync::atomic::{AtomicBool, Ordering};
 
 use ff::{
     Field,
     PrimeField,
 };
 
-struct ParsedLine<E: Engine> {
-    index: usize,
-    lc: LinearCombination<E>,
-    debug: String,
-    result: E::Fr,
-}
-
-struct Assignment<E: Engine> {
+struct Assignment {
     variable: Variable,
-    constrained: bool,
-    value: E::Fr,
-}
-
-fn empty_line<E:Engine>(index: usize) -> ParsedLine<E> {
-    ParsedLine::<E>{
-        index:index, 
-        lc: LinearCombination::zero(), 
-        debug: "".to_string(), 
-        result: E::Fr::zero(),
-    }
-}
-
-fn parse_line<E: Engine>(line: &String, variables: &mut Vec<Assignment<E>>, negate: bool) -> ParsedLine<E> {
-    let parts: Vec<&str> = line.split_whitespace().collect();
-    let variable: usize = parts[0].parse().unwrap();
-    let index: usize = parts[1].parse().unwrap();
-
-    // Bellman doesn't support parsing negative values.
-    let mut coefficient = E::Fr::from_str(parts[2].trim_left_matches("-")).unwrap();
-    if negate {
-        coefficient.negate();
-    }
-    if parts[2].starts_with("-") { 
-        coefficient.negate();
-    }
-    variables[variable] = Assignment::<E>{
-        variable: variables[variable].variable, 
-        constrained: true, 
-        value: variables[variable].value
-    };
-    let mut result = coefficient;
-    result.mul_assign(&(variables[variable].value));
-    ParsedLine::<E> {
-        index: index,
-        lc: LinearCombination::zero() + (coefficient, variables[variable].variable),
-        debug: format!("({}*{:?})", coefficient, variables[variable].value),
-        result: result,
-    }
-}
-
-fn read_next_constraint<E: Engine>(file: &mut BufReader<File>, variables: &mut Vec<Assignment<E>>, negate: bool) -> Option<ParsedLine<E>> {
-    let mut line = String::new();
-    let len = file.read_line(&mut line).unwrap();
-    if len > 0 {
-        Some(parse_line(&line, variables, negate))
-    } else {
-        None
-    }
+    constrained: AtomicBool,
 }
 
 fn parse_witness<F: PrimeField>(filename: &String) -> Vec<F> {
@@ -86,17 +34,6 @@ fn parse_witness<F: PrimeField>(filename: &String) -> Vec<F> {
     result
 }
 
-fn add_parsed_lines<E: Engine>(mut lhs: ParsedLine<E>,rhs: &ParsedLine<E>) -> ParsedLine<E> {
-    assert!(lhs.index == rhs.index);
-    lhs.result.add_assign(&rhs.result);
-    ParsedLine {
-        index: lhs.index,
-        lc: lhs.lc + &rhs.lc,
-        debug: lhs.debug + " + " + &rhs.debug,
-        result: lhs.result,
-    }
-}
-
 struct CircuitImpl<F: PrimeField> {
     primary_witness: Vec<F>,
     aux_witness: Vec<F>,
@@ -105,129 +42,102 @@ struct CircuitImpl<F: PrimeField> {
     qap_c: String,
 }
 
+#[derive(Copy, Clone)]
+enum Matrix {
+    A, B, C
+}
+struct LinearTerm<E: Engine> {
+    variable: usize,
+    coefficient: E::Fr,
+    matrix: Matrix,
+}
+
+fn read_linear_terms_from_file<E: Engine>(filename: &String, matrix: Matrix) -> Vec<(usize, LinearTerm<E>)> {
+    let file = File::open(&filename).expect("no such file");
+    let buf = BufReader::new(file);
+    buf.lines()
+        .map(|l| l.expect("Could not parse line"))
+        .collect::<Vec<String>>()
+        .into_par_iter()
+        .map(|line| {
+            let parts: Vec<&str> = line.split_whitespace().collect();
+            let variable: usize = parts[0].parse().unwrap();
+            let index: usize = parts[1].parse().unwrap();
+
+            // Bellman doesn't support parsing negative values.
+            let mut coefficient = E::Fr::from_str(parts[2].trim_left_matches("-")).unwrap();
+            if parts[2].starts_with("-") { 
+                coefficient.negate();
+            }
+            (index, LinearTerm { variable, coefficient, matrix})
+        }).collect()
+}
+
 impl<'a, E: Engine> Circuit<E> for &'a CircuitImpl<E::Fr> {
     fn synthesize<CS: ConstraintSystem<E>>(self, cs: &mut CS) -> Result<(), SynthesisError> {
         let now = Instant::now();
 
         println!("  {} Reading Witness", now.elapsed().as_secs());
-        let aux: Vec<Assignment<E>> = self.aux_witness.clone().into_iter()
+        let aux: Vec<Assignment> = self.aux_witness.clone().into_iter()
             .map(|value| Assignment {
                 variable: cs.alloc(|| "aux", || Ok(value)).unwrap(), 
-                constrained: false, 
-                value: value
+                constrained: AtomicBool::new(false),
             }).collect();
-        let primary: Vec<Assignment<E>> = self.primary_witness.clone().into_iter()
+        let primary: Vec<Assignment> = self.primary_witness.clone().into_iter()
             .map(|value| Assignment {
                 variable: cs.alloc_input(|| "primary", || Ok(value)).unwrap(), 
-                constrained: false, 
-                value: value
+                constrained: AtomicBool::new(false),
             }).collect();
 
         let mut vars = vec![
-            Assignment::<E>{
+            Assignment {
                 variable: CS::one(), 
-                constrained: false, 
-                value: E::Fr::one()
+                constrained: AtomicBool::new(false), 
             }];
         vars.extend(aux);
         vars.extend(primary);
 
         println!("  {} Reading QAP", now.elapsed().as_secs());
-        {
-            let mut qap_a_file = BufReader::new(File::open(&self.qap_a)?);
-            let mut qap_b_file = BufReader::new(File::open(&self.qap_b)?);
-            let mut qap_c_file = BufReader::new(File::open(&self.qap_c)?);
 
-            let mut current_a_lc = empty_line(0);
-            let mut next_a_lc = read_next_constraint::<E>(&mut qap_a_file, &mut vars, false);
+        // Map
+        let mut mapped = read_linear_terms_from_file::<E>(&self.qap_a, Matrix::A);
+        println!("    {} A done", now.elapsed().as_secs());
+        mapped.extend(read_linear_terms_from_file(&self.qap_b, Matrix::B));
+        println!("    {} B done", now.elapsed().as_secs());
+        mapped.extend(read_linear_terms_from_file(&self.qap_c, Matrix::C));
+        println!("    {} C done", now.elapsed().as_secs());
 
-            let mut current_b_lc = empty_line(0);
-            let mut next_b_lc = read_next_constraint::<E>(&mut qap_b_file, &mut vars, false);
+        // Group by index
+        let grouped = mapped.into_iter().collect::<MultiMap<_,_>>()
+            .into_iter().collect::<Vec<_>>();
+        println!("    {} grouped", now.elapsed().as_secs());
 
-            let mut current_c_lc = empty_line(0);
-            let mut next_c_lc = read_next_constraint::<E>(&mut qap_c_file, &mut vars, true);
-
-            while next_a_lc.is_some() || next_b_lc.is_some() || next_c_lc.is_some() {
-                while next_a_lc.is_some() {
-                    let mut advance = false;
-                    {
-                        let next = next_a_lc.as_ref().unwrap();
-                        if next.index < current_a_lc.index {
-                            println!("[WARNING] found term with index {} after index {}. This term will be ignored.", next.index, current_a_lc.index);
-                            advance = true
-                        } else if next.index == current_a_lc.index {
-                            current_a_lc = add_parsed_lines::<E>(current_a_lc, next);
-                            advance = true;
-                        }
+        // Reduce by key
+        let mut linear_combinations: Vec<(usize, LinearCombination<E>, LinearCombination<E>, LinearCombination<E>)> = grouped.into_par_iter()
+            .map(|kv| {
+                let mut lc_a = LinearCombination::<E>::zero();
+                let mut lc_b = LinearCombination::<E>::zero();
+                let mut lc_c = LinearCombination::<E>::zero();
+                for linear_term in kv.1 {
+                    match linear_term.matrix {
+                        Matrix::A => lc_a = lc_a + (linear_term.coefficient, vars[linear_term.variable].variable),
+                        Matrix::B => lc_b = lc_b + (linear_term.coefficient, vars[linear_term.variable].variable),
+                        Matrix::C => lc_c = lc_c - (linear_term.coefficient, vars[linear_term.variable].variable), 
                     }
-                    if advance {
-                        next_a_lc = read_next_constraint::<E>(&mut qap_a_file, &mut vars, false);
-                    } else {
-                        break;
-                    }
+                    vars[linear_term.variable].constrained.store(true, Ordering::Relaxed);
                 }
+                (kv.0, lc_a, lc_b, lc_c)
+            }).collect();
+        linear_combinations.sort_by(|lhs, rhs| lhs.0.cmp(&rhs.0));
 
-                while next_b_lc.is_some() {
-                    let mut advance = false;
-                    {
-                        let next = next_b_lc.as_ref().unwrap();
-                        if next.index < current_b_lc.index {
-                            println!("[WARNING] found term with index {} after index {}. This term will be ignored.", next.index, current_b_lc.index);
-                            advance = true
-                        } else if next.index == current_b_lc.index {
-                            current_b_lc.lc = current_b_lc.lc + &next.lc;
-                            current_b_lc.debug = current_b_lc.debug + " + " + &next.debug;
-                            current_b_lc.result.add_assign(&next.result);
-                            advance = true;
-                        }
-                    }
-                    if advance {
-                        next_b_lc = read_next_constraint::<E>(&mut qap_b_file, &mut vars, false);
-                    } else {
-                        break;
-                    }
-                }
-
-                while next_c_lc.is_some() {
-                    let mut advance = false;
-                    {
-                        let next = next_c_lc.as_ref().unwrap();
-                        if next.index < current_c_lc.index {
-                            println!("[WARNING] found term with index {} after index {}. This term will be ignored.", next.index, current_c_lc.index);
-                            advance = true
-                        } else if next.index == current_c_lc.index {
-                            current_c_lc.lc = current_c_lc.lc + &next.lc;
-                            current_c_lc.debug = current_c_lc.debug + " + " + &next.debug;
-                            current_c_lc.result.add_assign(&next.result);
-                            advance = true;
-                        }
-                    }
-                    if advance {
-                        next_c_lc = read_next_constraint::<E>(&mut qap_c_file, &mut vars, true);
-                    } else {
-                        break;
-                    }
-                }
-
-                assert!(current_a_lc.index == current_b_lc.index);
-                assert!(current_a_lc.index == current_c_lc.index);
-                //println!("Constraint: {} * {} = {}", current_a_lc.debug, current_b_lc.debug, current_c_lc.debug);
-
-                cs.enforce(
-                    || current_a_lc.index.to_string(),
-                    |lc| lc + &current_a_lc.lc,
-                    |lc| lc + &current_b_lc.lc,
-                    |lc| lc + &current_c_lc.lc,
-                );
-
-                current_a_lc.result.mul_assign(&current_b_lc.result);
-                assert!(current_a_lc.result == current_c_lc.result, 
-                format!("constraint {} failed: {} * {} != {}", current_a_lc.index, current_a_lc.debug, current_b_lc.debug, current_c_lc.debug));
-
-                current_a_lc = empty_line(current_a_lc.index + 1);
-                current_b_lc = empty_line(current_b_lc.index + 1);
-                current_c_lc = empty_line(current_c_lc.index + 1);
-            }
+        println!("    {} reduced", now.elapsed().as_secs());
+        for linear_combination in linear_combinations {
+            cs.enforce(
+                || linear_combination.0.to_string(),
+                |lc| lc + &linear_combination.1,
+                |lc| lc + &linear_combination.2,
+                |lc| lc + &linear_combination.3,
+            );
         }
 
         /*
@@ -237,7 +147,7 @@ impl<'a, E: Engine> Circuit<E> for &'a CircuitImpl<E::Fr> {
          * be the easier option for now.
          */
         for var in vars.iter() {
-            if !var.constrained {
+            if !var.constrained.load(Ordering::Relaxed) {
                 println!("[Warning] Unconstrained variable {:?}", var.variable);
                 cs.enforce(
                     || format!("unused var {:?}", var.variable),
@@ -247,7 +157,7 @@ impl<'a, E: Engine> Circuit<E> for &'a CircuitImpl<E::Fr> {
                 );
             }
         }
-
+        
         println!("  {} Done Reading", now.elapsed().as_secs());
         Ok(())
     }
@@ -278,12 +188,11 @@ fn main() {
         ::std::process::exit(1);
     }
 
-    use pairing::bn256::{Bn256, Fr};
+    use pairing::bn256::{Bn256};
     use rand::thread_rng;
-    use std::marker::PhantomData;
 
     use bellman::groth16::{
-        create_random_proof, generate_random_parameters, prepare_verifying_key, verify_proof, Proof,
+        create_random_proof, generate_random_parameters, prepare_verifying_key, verify_proof,
     };
 
     let rng = &mut thread_rng();
@@ -312,7 +221,6 @@ fn main() {
 
     println!("{} start verify_proof", now.elapsed().as_secs());
 
-    let file = File::open(&args[1]).unwrap();
     match verify_proof(&pvk, &proof, &primary) {
         Ok(v) => assert!(v),
         Err(e) => println!("error: {:?}", e)


### PR DESCRIPTION
This diff speed up reading the R1CS when trying to generate proofs with bellman by using a parallel map/reduce strategy for generating the R1CS based on the lines read from the input (code inspiration: https://gist.github.com/thereal1024/8075982816643cf9d5bd5851b61b63cc).

The main steps are:
1. Map: each line to constraint_index => variable, coefficient, a|b|c matrix
2. Reduce based on constraint_index => sum all linear terms (variable * coefficient) for each matrix and return the linear combination
3. Create constraints A * B = C for each such linear combination

We can expect this change to speed up reading the R1CS by at least a factor of two (From 2hours to < 1 hour for 268M constraints). 
Running it on 17M constraint system yielded the following results (note the time for "Done Reading"):

**Before**
```
0 start generate_random_parameters
  0 Reading Witness
  2 Reading QAP
  323 Done Reading
2275 start prepare_verifying_key
2275 start create_random_proof
  0 Reading Witness
  2 Reading QAP
  316 Done Reading
2723 start verify_proof
2723 Done
```

**After**
```
0 start generate_random_parameters
  0 Reading Witness
  2 Reading QAP
    7 A done
    28 B done
    44 C done
    73 grouped
    77 reduced
  114 Done Reading
2113 start prepare_verifying_key
2113 start create_random_proof
  0 Reading Witness
  3 Reading QAP
    9 A done
    31 B done
    48 C done
    93 grouped
    100 reduced
  125 Done Reading
2376 start verify_proof
```